### PR TITLE
Unify the context path for embedded Jetty and maven plugin

### DIFF
--- a/wicket-jquery-ui-samples/src/test/java/embedded/jetty/Start.java
+++ b/wicket-jquery-ui-samples/src/test/java/embedded/jetty/Start.java
@@ -51,10 +51,8 @@ public class Start {
 
 		WebAppContext bb = new WebAppContext();
 		bb.setServer(server);
-		bb.setContextPath("/");
+		bb.setContextPath("/jquery-ui-samples");
 		bb.setWar("src/main/webapp");
-
-		((AbstractSessionManager)bb.getSessionHandler().getSessionManager()).setUsingCookies(false);
 
 		// START JMX SERVER
 		// MBeanServer mBeanServer = ManagementFactory.getPlatformMBeanServer();


### PR DESCRIPTION
- Remove the restriction to encode jsessionid only in the url.
