### PR TITLE
Update WysiwygEditor.java

### DIFF
--- a/wicket-jquery-ui-plugins/src/main/java/com/googlecode/wicket/jquery/ui/plugins/wysiwyg/WysiwygEditor.java
+++ b/wicket-jquery-ui-plugins/src/main/java/com/googlecode/wicket/jquery/ui/plugins/wysiwyg/WysiwygEditor.java
@@ -91,6 +91,7 @@ public class WysiwygEditor extends FormComponentPanel<String> implements IJQuery
 		this.add(this.container);
 
 		this.textarea = new TextArea<String>("textarea", Model.of(this.getModelObject()));
+		this.textarea.setEscapeModelStrings(false);
 		this.add(this.textarea.setOutputMarkupId(true));
 
 		if (toolbar != null)


### PR DESCRIPTION
Text modified via WysiwygEditor displayed incorrectly due to "input" text escaping.
