### PR TITLE
setEscapeModelStrings set to false

### DIFF
--- a/wicket-jquery-ui-plugins/src/main/java/com/googlecode/wicket/jquery/ui/plugins/wysiwyg/WysiwygEditor.java
+++ b/wicket-jquery-ui-plugins/src/main/java/com/googlecode/wicket/jquery/ui/plugins/wysiwyg/WysiwygEditor.java
@@ -93,6 +93,7 @@ public class WysiwygEditor extends FormComponentPanel<String> implements IJQuery
 		{
 			toolbar.attachToEditor(this.container);
 		}
+		setEscapeModelStrings(false);
 	}
 
 	// Properties //


### PR DESCRIPTION
If you update the model and not reload the whole page, the HTML-Tags are visible in the editor
