### PR TITLE
fixed onEdit / reading from e.event instead from data

### DIFF
--- a/wicket-kendo-ui/src/main/java/com/googlecode/wicket/kendo/ui/scheduler/SchedulerBehavior.java
+++ b/wicket-kendo-ui/src/main/java/com/googlecode/wicket/kendo/ui/scheduler/SchedulerBehavior.java
@@ -229,19 +229,22 @@ public abstract class SchedulerBehavior extends KendoUIBehavior implements IJQue
 
 				parameters.add(CallbackParameter.context("e"));
 
+				//NOTE! edit is a scheduler-related event and does not contain data, like datasource-related events
+				//read e.event instead
+				
 				// event //
-				parameters.add(CallbackParameter.resolved("id", "e.data.id")); // retrieved
-				parameters.add(CallbackParameter.resolved("title", "e.data.title")); // retrieved
-				parameters.add(CallbackParameter.resolved("description", "e.data.description")); // retrieved
+				parameters.add(CallbackParameter.resolved("id", "e.event.id")); // retrieved
+				parameters.add(CallbackParameter.resolved("title", "e.event.title")); // retrieved
+				parameters.add(CallbackParameter.resolved("description", "e.event.description")); // retrieved
 
-				parameters.add(CallbackParameter.resolved("start", "e.data.start.getTime()")); // retrieved
-				parameters.add(CallbackParameter.resolved("end", "e.data.end.getTime()")); // retrieved
-				parameters.add(CallbackParameter.resolved("isAllDay", "e.data.isAllDay")); // retrieved
+				parameters.add(CallbackParameter.resolved("start", "e.event.start.getTime()")); // retrieved
+				parameters.add(CallbackParameter.resolved("end", "e.event.end.getTime()")); // retrieved
+				parameters.add(CallbackParameter.resolved("isAllDay", "e.event.isAllDay")); // retrieved
 
 				// recurrence //
-				parameters.add(CallbackParameter.resolved("recurrenceId", "e.data.recurrenceId")); // retrieved
-				parameters.add(CallbackParameter.resolved("recurrenceRule", "e.data.recurrenceRule")); // retrieved
-				parameters.add(CallbackParameter.resolved("recurrenceException", "e.data.recurrenceException")); // retrieved
+				parameters.add(CallbackParameter.resolved("recurrenceId", "e.event.recurrenceId")); // retrieved
+				parameters.add(CallbackParameter.resolved("recurrenceRule", "e.event.recurrenceRule")); // retrieved
+				parameters.add(CallbackParameter.resolved("recurrenceException", "e.event.recurrenceException")); // retrieved
 
 				// resources //
 				for (String field : SchedulerBehavior.this.getResourceListModel().getFields())


### PR DESCRIPTION
Hi Sebastien,
could you please pull and have a look at onEdit() and SchedulerPayload?

```
// resources //
for (String field : SchedulerBehavior.this.getResourceListModel().getFields())
{
    parameters.add(CallbackParameter.resolved(field, "e.event." + field)); // retrieved
}
```

The parameter resolving code of onEdit() does not work for ResourceIDs, and I dont no why.

```
public SchedulerPayload(final ResourceListModel listModel)
{
        ...
    for (ResourceList list : listModel.getObject())
    {
        String field = list.getField();
        StringValue value = RequestCycleUtils.getQueryParameterValue(field);
        ...
```

`RequestCycleUtils.getQueryParameterValue(field)` always returns a String.
It looks like an unevaluated json object `[Object, Object]` or something.

For DataSource-related events it works perfect.
There the resolving code looks the same, but just resolved from 'data', not 'event'.
`CallbackParameter.resolved(field, "e.data." + field)`.
There I get something like `[1,2]` in SchedulerPayload, which are correct ResourceIDs.

It seems to me `Wicket.Ajax.ajax(attrs);` behaves different on packing query parameters.
But I dont have much experience with `Wicket.Ajax` stuff.

thanx a lot
Patrick
