### PR TITLE
implemented equals and hashCode for Resource/Id to enable them be used in Choices

### DIFF
--- a/wicket-kendo-ui/src/main/java/com/googlecode/wicket/kendo/ui/scheduler/resource/Id.java
+++ b/wicket-kendo-ui/src/main/java/com/googlecode/wicket/kendo/ui/scheduler/resource/Id.java
@@ -159,4 +159,31 @@ public class Id<T> implements IClusterable
 			return String.valueOf(this.get());
 		}
 	}
+
+	@Override
+	public int hashCode() {
+		final int prime = 31;
+		int result = 1;
+		result = prime * result + ((id == null) ? 0 : id.hashCode());
+		return result;
+	}
+
+	@Override
+	public boolean equals(Object obj) {
+		if (this == obj)
+			return true;
+		if (obj == null)
+			return false;
+		if (getClass() != obj.getClass())
+			return false;
+		Id other = (Id) obj;
+		if (id == null) {
+			if (other.id != null)
+				return false;
+		} else if (!id.equals(other.id))
+			return false;
+		return true;
+	}
+	
+	
 }

--- a/wicket-kendo-ui/src/main/java/com/googlecode/wicket/kendo/ui/scheduler/resource/Resource.java
+++ b/wicket-kendo-ui/src/main/java/com/googlecode/wicket/kendo/ui/scheduler/resource/Resource.java
@@ -189,4 +189,31 @@ public class Resource implements Serializable
 
 		return value.toString();
 	}
+
+	@Override
+	public int hashCode() {
+		final int prime = 31;
+		int result = 1;
+		result = prime * result + ((id == null) ? 0 : id.hashCode());
+		return result;
+	}
+
+	@Override
+	public boolean equals(Object obj) {
+		if (this == obj)
+			return true;
+		if (obj == null)
+			return false;
+		if (getClass() != obj.getClass())
+			return false;
+		Resource other = (Resource) obj;
+		if (id == null) {
+			if (other.id != null)
+				return false;
+		} else if (!id.equals(other.id))
+			return false;
+		return true;
+	}
+	
+	
 }


### PR DESCRIPTION
Hi Sebastien,
I'm using the Resource class quite straight-forward as model-beans in `RadioChoices` for filtering features for my scheduler instance on page. To let the Choices be able to select Resource when clicked/chosen, I implemented equals/hashCode for `Resource` and `Id`.

I always let equals/hashCode generate by Eclipse, and I'm not sure if they fit your style, so please have a short look at it.

Thanx for merging...
best regards
Patrick
