### PR TITLE
Add factory methods for the (Input|Message)Window inner components

### DIFF
--- a/wicket-kendo-ui/src/main/java/com/googlecode/wicket/kendo/ui/widget/window/InputWindow.java
+++ b/wicket-kendo-ui/src/main/java/com/googlecode/wicket/kendo/ui/widget/window/InputWindow.java
@@ -147,33 +147,6 @@ public abstract class InputWindow<T> extends Window<T>
 		this.form.add(this.newButtonPanel("buttons", this.getButtons()));
 	}
 
-	/**
-	 * Factory method for creating the form component that will be used as an input.<br/>
-	 * Override this method when you need to use different input type, e.g. NumberTextField or PasswordField.
-	 *
-	 * @param id The component id
-	 * @param model The model with the label text
-	 * @return The label component.
-	 */
-	protected FormComponent<T> newTextField(String id, IModel<T> model)
-	{
-		return new TextField<T>(id, model);
-	}
-
-	/**
-	 * Factory method for creating the component that will be used as a label in the
-	 * window.<br/>
-	 * Override this method when you need to show formatted label.
-	 *
-	 * @param id The component id
-	 * @param model The model with the label text
-	 * @return The label component.
-	 */
-	protected Component newLabel(String id, IModel<String> model)
-	{
-		return new Label(id, model);
-	}
-
 	@Override
 	protected void onOpen(AjaxRequestTarget target)
 	{
@@ -204,6 +177,13 @@ public abstract class InputWindow<T> extends Window<T>
 		}
 	}
 
+	@Override
+	protected void onDetach()
+	{
+		super.onDetach();
+		labelModel.detach();
+	}
+
 	/**
 	 * Triggered when the 'submit' button is clicked, and the validation succeed
 	 *
@@ -222,6 +202,33 @@ public abstract class InputWindow<T> extends Window<T>
 	}
 
 	// Factories //
+
+	/**
+	 * Factory method for creating the form component that will be used as an input.<br/>
+	 * Override this method when you need to use different input type, e.g. NumberTextField or PasswordField.
+	 *
+	 * @param id The component id
+	 * @param model The model with the label text
+	 * @return The label component.
+	 */
+	protected FormComponent<T> newTextField(String id, IModel<T> model)
+	{
+		return new TextField<T>(id, model);
+	}
+
+	/**
+	 * Factory method for creating the component that will be used as a label in the
+	 * window.<br/>
+	 * Override this method when you need to show formatted label.
+	 *
+	 * @param id The component id
+	 * @param model The model with the label text
+	 * @return The label component.
+	 */
+	protected Component newLabel(String id, IModel<String> model)
+	{
+		return new Label(id, model);
+	}
 
 	/**
 	 * Gets a new {@link Form}

--- a/wicket-kendo-ui/src/main/java/com/googlecode/wicket/kendo/ui/widget/window/InputWindow.java
+++ b/wicket-kendo-ui/src/main/java/com/googlecode/wicket/kendo/ui/widget/window/InputWindow.java
@@ -16,9 +16,11 @@
  */
 package com.googlecode.wicket.kendo.ui.widget.window;
 
+import org.apache.wicket.Component;
 import org.apache.wicket.ajax.AjaxRequestTarget;
 import org.apache.wicket.markup.html.basic.Label;
 import org.apache.wicket.markup.html.form.Form;
+import org.apache.wicket.markup.html.form.FormComponent;
 import org.apache.wicket.model.IModel;
 import org.apache.wicket.model.Model;
 
@@ -41,6 +43,8 @@ public abstract class InputWindow<T> extends Window<T>
 	private final KendoFeedbackPanel feedback;
 
 	private final Form<?> form;
+
+	private IModel<String> labelModel;
 
 	/**
 	 * Constructor
@@ -91,6 +95,8 @@ public abstract class InputWindow<T> extends Window<T>
 	{
 		super(id, title, model, WindowButtons.OK_CANCEL);
 
+		this.labelModel = label;
+
 		// form //
 		this.form = InputWindow.newForm("form");
 		this.add(this.form);
@@ -98,9 +104,6 @@ public abstract class InputWindow<T> extends Window<T>
 		// feedback //
 		this.feedback = new KendoFeedbackPanel("feedback");
 		this.form.add(this.feedback);
-
-		// label //
-		this.form.add(new Label("label", label));
 	}
 
 	// Properties //
@@ -134,11 +137,41 @@ public abstract class InputWindow<T> extends Window<T>
 	{
 		super.onInitialize();
 
+		// label //
+		this.form.add(newLabel("label", labelModel));
+
 		// field //
-		this.form.add(new TextField<T>("input", this.getModel()).setRequired(this.isRequired()));
+		this.form.add(newTextField("input", this.getModel()).setRequired(this.isRequired()));
 
 		// buttons //
 		this.form.add(this.newButtonPanel("buttons", this.getButtons()));
+	}
+
+	/**
+	 * Factory method for creating the form component that will be used as an input.<br/>
+	 * Override this method when you need to use different input type, e.g. NumberTextField or PasswordField.
+	 *
+	 * @param id The component id
+	 * @param model The model with the label text
+	 * @return The label component.
+	 */
+	protected FormComponent<T> newTextField(String id, IModel<T> model)
+	{
+		return new TextField<T>(id, model);
+	}
+
+	/**
+	 * Factory method for creating the component that will be used as a label in the
+	 * window.<br/>
+	 * Override this method when you need to show formatted label.
+	 *
+	 * @param id The component id
+	 * @param model The model with the label text
+	 * @return The label component.
+	 */
+	protected Component newLabel(String id, IModel<String> model)
+	{
+		return new Label(id, model);
 	}
 
 	@Override

--- a/wicket-kendo-ui/src/main/java/com/googlecode/wicket/kendo/ui/widget/window/MessageWindow.java
+++ b/wicket-kendo-ui/src/main/java/com/googlecode/wicket/kendo/ui/widget/window/MessageWindow.java
@@ -179,6 +179,14 @@ public abstract class MessageWindow extends Window<String>
 		this.form.add(this.newButtonPanel("buttons", this.getButtons()));
 	}
 
+	@Override
+	protected void onOpen(AjaxRequestTarget target)
+	{
+		target.add(this.label);
+	}
+
+	// Factories //
+
 	/**
 	 * Factory method for creating the component that will be used as a label in the
 	 * window.<br/>
@@ -192,14 +200,6 @@ public abstract class MessageWindow extends Window<String>
 	{
 		return new Label(id, model).setOutputMarkupId(true);
 	}
-
-	@Override
-	protected void onOpen(AjaxRequestTarget target)
-	{
-		target.add(this.label);
-	}
-
-	// Factories //
 
 	/**
 	 * Gets a new {@link Form}

--- a/wicket-kendo-ui/src/main/java/com/googlecode/wicket/kendo/ui/widget/window/MessageWindow.java
+++ b/wicket-kendo-ui/src/main/java/com/googlecode/wicket/kendo/ui/widget/window/MessageWindow.java
@@ -19,6 +19,7 @@ package com.googlecode.wicket.kendo.ui.widget.window;
 import java.util.List;
 
 import org.apache.wicket.AttributeModifier;
+import org.apache.wicket.Component;
 import org.apache.wicket.ajax.AjaxRequestTarget;
 import org.apache.wicket.markup.html.basic.Label;
 import org.apache.wicket.markup.html.form.Form;
@@ -37,7 +38,7 @@ public abstract class MessageWindow extends Window<String>
 {
 	private static final long serialVersionUID = 1L;
 
-	private Label label;
+	private Component label;
 	private final Form<?> form;
 
 	/**
@@ -150,10 +151,6 @@ public abstract class MessageWindow extends Window<String>
 		// icon //
 		this.add(new EmptyPanel("icon").add(AttributeModifier.append("class", KendoIcon.getCssClass(icon))));
 
-		// label //
-		this.label = new Label("text", this.getModel());
-		this.add(this.label.setOutputMarkupId(true));
-
 		// form //
 		this.form = MessageWindow.newForm("form");
 		this.add(this.form);
@@ -174,8 +171,26 @@ public abstract class MessageWindow extends Window<String>
 	{
 		super.onInitialize();
 
+		// label //
+		this.label = newLabel("text", this.getModel());
+		this.add(this.label);
+
 		// buttons //
 		this.form.add(this.newButtonPanel("buttons", this.getButtons()));
+	}
+
+	/**
+	 * Factory method for creating the component that will be used as a label in the
+	 * window.<br/>
+	 * Override this method when you need to show formatted label.
+	 *
+	 * @param id The component id
+	 * @param model The model with the label text
+	 * @return The label component.
+	 */
+	protected Component newLabel(String id, IModel<String> model)
+	{
+		return new Label(id, model).setOutputMarkupId(true);
 	}
 
 	@Override


### PR DESCRIPTION
This way it is possible to add formatting to the label (either custom component, or MultiLineLabel or even just making possible to call #setEscapeModelStrings(false)) or use NumberTextField.