### PR TITLE
Allow using custom values as identifier for Sortable items

### DIFF
--- a/wicket-jquery-ui/src/main/java/com/googlecode/wicket/jquery/ui/interaction/sortable/Sortable.java
+++ b/wicket-jquery-ui/src/main/java/com/googlecode/wicket/jquery/ui/interaction/sortable/Sortable.java
@@ -271,16 +271,23 @@ public abstract class Sortable<T> extends JQueryGenericContainer<List<T>> implem
 			}
 
 			@Override
-			protected T findItem(String hash, List<T> list)
+			protected T findItem(String id, List<T> list)
 			{
-				return Sortable.this.findItem(hash, list);
+				return Sortable.this.findItem(id, list);
 			}
 		};
 	}
 
-	protected T findItem(String hash, List<T> list)
+	/**
+	 * A helper method to locate an item in a list by identifier
+	 *
+	 * @param id The identifier of the item
+	 * @param list The list of items
+	 * @return The item with that identifier or {@code null} if there is no such
+	 */
+	protected T findItem(String id, List<T> list)
 	{
-		return ListUtils.fromHash(Integer.parseInt(hash, 10), list);
+		return ListUtils.fromHash(Integer.parseInt(id, 10), list);
 	}
 
 	/**

--- a/wicket-jquery-ui/src/main/java/com/googlecode/wicket/jquery/ui/interaction/sortable/Sortable.java
+++ b/wicket-jquery-ui/src/main/java/com/googlecode/wicket/jquery/ui/interaction/sortable/Sortable.java
@@ -269,7 +269,18 @@ public abstract class Sortable<T> extends JQueryGenericContainer<List<T>> implem
 			{
 				Sortable.this.onRemove(target, item);
 			}
+
+			@Override
+			protected T findItem(String hash, List<T> list)
+			{
+				return Sortable.this.findItem(hash, list);
+			}
 		};
+	}
+
+	protected T findItem(String hash, List<T> list)
+	{
+		return ListUtils.fromHash(Integer.parseInt(hash, 10), list);
 	}
 
 	/**

--- a/wicket-jquery-ui/src/main/java/com/googlecode/wicket/jquery/ui/interaction/sortable/SortableBehavior.java
+++ b/wicket-jquery-ui/src/main/java/com/googlecode/wicket/jquery/ui/interaction/sortable/SortableBehavior.java
@@ -134,7 +134,7 @@ public abstract class SortableBehavior<T> extends JQueryUIBehavior implements IJ
 		if (event instanceof SortableEvent)
 		{
 			SortableEvent ev = (SortableEvent) event;
-			int hash = ev.getHash();
+			String hash = ev.getHash();
 			int index = ev.getIndex();
 
 			if (event instanceof UpdateEvent)
@@ -143,7 +143,7 @@ public abstract class SortableBehavior<T> extends JQueryUIBehavior implements IJ
 
 				if (list != null)
 				{
-					this.onUpdate(target, ListUtils.fromHash(hash, list), index);
+					this.onUpdate(target, findItem(hash, list), index);
 				}
 			}
 
@@ -153,7 +153,7 @@ public abstract class SortableBehavior<T> extends JQueryUIBehavior implements IJ
 
 				if (!list.isEmpty())
 				{
-					this.onReceive(target, ListUtils.fromHash(hash, list), index);
+					this.onReceive(target, findItem(hash, list), index);
 				}
 			}
 
@@ -163,10 +163,15 @@ public abstract class SortableBehavior<T> extends JQueryUIBehavior implements IJ
 
 				if (list != null)
 				{
-					this.onRemove(target, ListUtils.fromHash(hash, list));
+					this.onRemove(target, findItem(hash, list));
 				}
 			}
 		}
+	}
+
+	protected T findItem(String hash, List<T> list)
+	{
+		return ListUtils.fromHash(Integer.parseInt(hash, 10), list);
 	}
 
 	// Factories //
@@ -253,12 +258,12 @@ public abstract class SortableBehavior<T> extends JQueryUIBehavior implements IJ
 	 */
 	protected static class SortableEvent extends JQueryEvent
 	{
-		private final int hash;
+		private final String hash;
 		private final int index;
 
 		public SortableEvent()
 		{
-			this.hash = RequestCycleUtils.getQueryParameterValue("hash").toInt(0);
+			this.hash = RequestCycleUtils.getQueryParameterValue("hash").toString();
 			this.index = RequestCycleUtils.getQueryParameterValue("index").toInt(-1); // remove-behavior will default to -1
 		}
 
@@ -267,7 +272,7 @@ public abstract class SortableBehavior<T> extends JQueryUIBehavior implements IJ
 		 *
 		 * @return the hash
 		 */
-		public int getHash()
+		public String getHash()
 		{
 			return this.hash;
 		}

--- a/wicket-jquery-ui/src/main/java/com/googlecode/wicket/jquery/ui/interaction/sortable/SortableBehavior.java
+++ b/wicket-jquery-ui/src/main/java/com/googlecode/wicket/jquery/ui/interaction/sortable/SortableBehavior.java
@@ -169,9 +169,16 @@ public abstract class SortableBehavior<T> extends JQueryUIBehavior implements IJ
 		}
 	}
 
-	protected T findItem(String hash, List<T> list)
+	/**
+	 * A helper method to locate an item in a list by identifier
+	 *
+	 * @param id The identifier of the item
+	 * @param list The list of items
+	 * @return The item with that identifier or {@code null} if there is no such
+	 */
+	protected T findItem(String id, List<T> list)
 	{
-		return ListUtils.fromHash(Integer.parseInt(hash, 10), list);
+		return ListUtils.fromHash(Integer.parseInt(id, 10), list);
 	}
 
 	// Factories //


### PR DESCRIPTION
Change the type of SortableEvent#hash to String and move the casting to int in SortableBehavior#findItem()/Sortable#findItem().
This way a specialization of Sortable(Behavior) could use something else than the hashCode if needed.