### PR TITLE
Fix quoting in strings.

### DIFF
--- a/wicket-jquery-ui-core/src/main/java/com/googlecode/wicket/jquery/core/renderer/TextRenderer.java
+++ b/wicket-jquery-ui-core/src/main/java/com/googlecode/wicket/jquery/core/renderer/TextRenderer.java
@@ -94,7 +94,7 @@ public class TextRenderer<T> implements ITextRenderer<T>
 
 			if (value != null)
 			{
-				return value.toString();
+				return value.toString().replace("\"", "\\\"");
 			}
 		}
 


### PR DESCRIPTION
If a string contains double quotes (") these produce invalid JSON. This fix replaces " with \"