### PR TITLE
Calendar / ViewRenderEvent throws an exception when parsing LocalDate…

### DIFF
--- a/wicket-jquery-ui-calendar/src/main/java/com/googlecode/wicket/jquery/ui/calendar/Calendar.java
+++ b/wicket-jquery-ui-calendar/src/main/java/com/googlecode/wicket/jquery/ui/calendar/Calendar.java
@@ -22,6 +22,7 @@ import org.apache.wicket.ajax.AjaxRequestTarget;
 import org.apache.wicket.core.request.handler.IPartialPageRequestHandler;
 import org.apache.wicket.util.lang.Args;
 import org.apache.wicket.util.lang.Generics;
+import org.threeten.bp.LocalDate;
 import org.threeten.bp.LocalDateTime;
 
 import com.googlecode.wicket.jquery.core.JQueryBehavior;
@@ -245,7 +246,7 @@ public class Calendar extends JQueryContainer implements ICalendarListener
 	}
 
 	@Override
-	public void onViewRender(AjaxRequestTarget target, CalendarView view, LocalDateTime start, LocalDateTime end)
+	public void onViewRender(AjaxRequestTarget target, CalendarView view, LocalDate start, LocalDate end)
 	{
 		// noop
 	}

--- a/wicket-jquery-ui-calendar/src/main/java/com/googlecode/wicket/jquery/ui/calendar/CalendarAdapter.java
+++ b/wicket-jquery-ui-calendar/src/main/java/com/googlecode/wicket/jquery/ui/calendar/CalendarAdapter.java
@@ -17,6 +17,7 @@
 package com.googlecode.wicket.jquery.ui.calendar;
 
 import org.apache.wicket.ajax.AjaxRequestTarget;
+import org.threeten.bp.LocalDate;
 import org.threeten.bp.LocalDateTime;
 
 /**
@@ -119,7 +120,7 @@ public class CalendarAdapter implements ICalendarListener
 	}
 
 	@Override
-	public void onViewRender(AjaxRequestTarget target, CalendarView view, LocalDateTime start, LocalDateTime end)
+	public void onViewRender(AjaxRequestTarget target, CalendarView view, LocalDate start, LocalDate end)
 	{
 		// noop
 	}

--- a/wicket-jquery-ui-calendar/src/main/java/com/googlecode/wicket/jquery/ui/calendar/CalendarBehavior.java
+++ b/wicket-jquery-ui-calendar/src/main/java/com/googlecode/wicket/jquery/ui/calendar/CalendarBehavior.java
@@ -806,8 +806,8 @@ public class CalendarBehavior extends JQueryBehavior implements IJQueryAjaxAware
 	 */
 	protected static class ViewRenderEvent extends JQueryEvent
 	{
-		private final LocalDateTime start;
-		private final LocalDateTime end;
+		private final LocalDate start;
+		private final LocalDate end;
 		private final String viewName;
 
 		/**
@@ -816,10 +816,10 @@ public class CalendarBehavior extends JQueryBehavior implements IJQueryAjaxAware
 		public ViewRenderEvent()
 		{
 			String start = RequestCycleUtils.getQueryParameterValue("startDate").toString();
-			this.start = LocalDateTime.parse(start);
+			this.start = LocalDate.parse(start);
 
 			String end = RequestCycleUtils.getQueryParameterValue("endDate").toString();
-			this.end = LocalDateTime.parse(end);
+			this.end = LocalDate.parse(end);
 
 			this.viewName = RequestCycleUtils.getQueryParameterValue("viewName").toString();
 		}
@@ -829,7 +829,7 @@ public class CalendarBehavior extends JQueryBehavior implements IJQueryAjaxAware
 		 *
 		 * @return the start date
 		 */
-		public LocalDateTime getStart()
+		public LocalDate getStart()
 		{
 			return this.start;
 		}
@@ -839,7 +839,7 @@ public class CalendarBehavior extends JQueryBehavior implements IJQueryAjaxAware
 		 *
 		 * @return the end date
 		 */
-		public LocalDateTime getEnd()
+		public LocalDate getEnd()
 		{
 			return this.end;
 		}

--- a/wicket-jquery-ui-calendar/src/main/java/com/googlecode/wicket/jquery/ui/calendar/ICalendarListener.java
+++ b/wicket-jquery-ui-calendar/src/main/java/com/googlecode/wicket/jquery/ui/calendar/ICalendarListener.java
@@ -18,6 +18,7 @@ package com.googlecode.wicket.jquery.ui.calendar;
 
 import org.apache.wicket.ajax.AjaxRequestTarget;
 import org.apache.wicket.util.io.IClusterable;
+import org.threeten.bp.LocalDate;
 import org.threeten.bp.LocalDateTime;
 
 /**
@@ -173,8 +174,8 @@ public interface ICalendarListener extends IClusterable
 	 *
 	 * @param target the {@link AjaxRequestTarget}
 	 * @param view the current calendar view
-	 * @param start the start {@link LocalDateTime} of the current view
-	 * @param end the event end {@link LocalDateTime} of the current view
+	 * @param start the start {@link LocalDate} of the current view
+	 * @param end the event end {@link LocalDate} of the current view
 	 */
-	void onViewRender(AjaxRequestTarget target, CalendarView view, LocalDateTime start, LocalDateTime end);
+	void onViewRender(AjaxRequestTarget target, CalendarView view, LocalDate start, LocalDate end);
 }

--- a/wicket-jquery-ui-samples/src/main/java/com/googlecode/wicket/jquery/ui/samples/jqueryui/calendar/ExtendedCalendarPage.java
+++ b/wicket-jquery-ui-samples/src/main/java/com/googlecode/wicket/jquery/ui/samples/jqueryui/calendar/ExtendedCalendarPage.java
@@ -5,6 +5,7 @@ import java.util.Date;
 import org.apache.wicket.ajax.AjaxRequestTarget;
 import org.apache.wicket.markup.html.form.Form;
 import org.apache.wicket.markup.html.panel.FeedbackPanel;
+import org.threeten.bp.LocalDate;
 import org.threeten.bp.LocalDateTime;
 import org.threeten.bp.temporal.ChronoUnit;
 
@@ -91,6 +92,10 @@ public class ExtendedCalendarPage extends AbstractCalendarPage
 			@Override
 			public boolean isEventResizeEnabled()
 			{
+				return true;
+			}
+			@Override
+			public boolean isViewRenderEnabled() {
 				return true;
 			}
 


### PR DESCRIPTION
#248  …LocalDateTime without time information 

Hi Sébastien,

I enabled the ViewRender on the Sample app to reproduce the bug. Then modified the code to use the LocalDate type, did some tests, it works.

Great work btw.. This plugin seems really nice !