### PR TITLE
Hrefs with protocols are being stripped

### DIFF
--- a/wicket-jquery-ui-plugins/src/main/java/com/googlecode/wicket/jquery/ui/plugins/wysiwyg/WysiwygEditor.java
+++ b/wicket-jquery-ui-plugins/src/main/java/com/googlecode/wicket/jquery/ui/plugins/wysiwyg/WysiwygEditor.java
@@ -196,7 +196,8 @@ public class WysiwygEditor extends FormComponentPanel<String> implements IJQuery
 		return new HtmlPolicyBuilder() // lf
 				.allowCommonInlineFormattingElements() // lf
 				.allowCommonBlockElements() // lf
-				.allowElements("a").allowAttributes("href", "target").onElements("a") // lf
+				.allowElements("a").allowStandardUrlProtocols() // lf
+				.allowAttributes("href", "target").onElements("a") // lf
 				.allowAttributes("size").onElements("font") // lf
 				.allowAttributes("class", "style").globally() // lf
 				.toFactory();


### PR DESCRIPTION
This tiny fix allows absolute URLs to be entered i.e. `http://example.com`, `https://example.com`, `mailto:https@example.com`