### PR TITLE
owasp-sanitizer version is updated

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -45,7 +45,7 @@
 
 	<properties>
 		<wicket.version>8.3.0</wicket.version>
-		<owasp-sanitizer.version>20171016.1</owasp-sanitizer.version>
+		<owasp-sanitizer.version>20190325.1</owasp-sanitizer.version>
 		<junit.version>4.12</junit.version>
 		<jetty.version>8.1.16.v20140903</jetty.version>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>


### PR DESCRIPTION
This fix can't be backported to 7.x due to this library requires Java8
https://groups.google.com/forum/#!topic/owasp-java-html-sanitizer-announce/ebauBXFIf58