### PR TITLE
Fixes issue #308: Better work with single 'y' in date pattern

### DIFF
--- a/wicket-kendo-ui/src/main/java/com/googlecode/wicket/kendo/ui/form/datetime/DateTimePicker.java
+++ b/wicket-kendo-ui/src/main/java/com/googlecode/wicket/kendo/ui/form/datetime/DateTimePicker.java
@@ -146,7 +146,15 @@ public class DateTimePicker extends FormComponentPanel<Date> implements ITextFor
 		super(id, model);
 
 		this.locale = locale;
-		this.datePattern = datePattern;
+		// single 'y' is allowed in Java11, but *NOT* being work as expected while using with DateTimeFormatter
+		if (datePattern.contains("y") && !datePattern.contains("yy"))
+		{
+			this.datePattern = datePattern.replace("y", "yy");
+		}
+		else
+		{
+			this.datePattern = datePattern;
+		}
 		this.timePattern = timePattern;
 
 		this.setType(Date.class); // makes use of the converter
@@ -314,7 +322,7 @@ public class DateTimePicker extends FormComponentPanel<Date> implements ITextFor
 
 	/**
 	 * Gets a new {@link Date} {@link IConverter}.
-	 * 
+	 *
 	 * @param format the time format
 	 * @return the converter
 	 */
@@ -357,7 +365,7 @@ public class DateTimePicker extends FormComponentPanel<Date> implements ITextFor
 
 				this.setEnabled(DateTimePicker.this.isEnabled());
 			}
-			
+
 			// methods //
 
 			@Override

--- a/wicket-kendo-ui/src/main/java/com/googlecode/wicket/kendo/ui/utils/KendoDateTimeUtils.java
+++ b/wicket-kendo-ui/src/main/java/com/googlecode/wicket/kendo/ui/utils/KendoDateTimeUtils.java
@@ -84,11 +84,6 @@ public class KendoDateTimeUtils
 		{
 			converted = converted.replace("a", "aa");
 		}
-		// single 'y' is allowed in Java11, but *NOT* allowed in kendo
-		if (converted.contains("y") && !converted.contains("yy"))
-		{
-			converted = converted.replace("y", "yy");
-		}
 
 		for (int i = 0; i < chars_lenth; i++)
 		{


### PR DESCRIPTION
Hello @sebfz1,

here is the better fix for the old issue

TL;DR;
recently we got this https://issues.apache.org/jira/browse/OPENMEETINGS-2142 bug report
surprisingly this turns to be the same #308 but from the other side

This test https://github.com/apache/openmeetings/blob/master/openmeetings-web/src/test/java/org/apache/openmeetings/util/TestDateTime.java#L36 shows the problem:

Single 'y' in pattern produces year `0019` instead of `2019`