### PR TITLE
Wicket9.x partial migration

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -44,8 +44,8 @@
 	</scm>
 
 	<properties>
-		<wicket.version>9.0.0-M3</wicket.version>
-		<owasp-sanitizer.version>20190325.1</owasp-sanitizer.version>
+		<wicket.version>9.0.0-M4</wicket.version>
+		<owasp-sanitizer.version>20191001.1</owasp-sanitizer.version>
 		<junit.version>5.5.2</junit.version>
 		<jetty.version>9.4.16.v20190411</jetty.version>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/wicket-jquery-ui-core/src/main/java/com/googlecode/wicket/jquery/core/resource/JQueryGlobalizeHeaderItem.java
+++ b/wicket-jquery-ui-core/src/main/java/com/googlecode/wicket/jquery/core/resource/JQueryGlobalizeHeaderItem.java
@@ -28,11 +28,11 @@ import com.googlecode.wicket.jquery.core.settings.JQueryLibrarySettings;
  * public void renderHead(IHeaderResponse response)
  * {
  * 	super.renderHead(response);
- * 	
+ *
  * 	response.render(new JQueryGlobalizeHeaderItem());
  * }
  * </code></pre>
- * 
+ *
  * @author Sebastien Briquet - sebfz1
  * @see JQueryLibrarySettings#getJQueryGlobalizeReference()
  *
@@ -46,6 +46,6 @@ public class JQueryGlobalizeHeaderItem extends JavaScriptReferenceHeaderItem
 	 */
 	public JQueryGlobalizeHeaderItem()
 	{
-		super(JQueryGlobalizeResourceReference.get(), null, "jquery-globalize", false, null, null);
+		super(JQueryGlobalizeResourceReference.get(), null, "jquery-globalize");
 	}
 }

--- a/wicket-jquery-ui-core/src/main/java/com/googlecode/wicket/jquery/core/resource/JavaScriptPackageHeaderItem.java
+++ b/wicket-jquery-ui-core/src/main/java/com/googlecode/wicket/jquery/core/resource/JavaScriptPackageHeaderItem.java
@@ -26,7 +26,7 @@ import org.apache.wicket.resource.TextTemplateResourceReference;
 /**
  * Provides a {@link JavaScriptReferenceHeaderItem} that will load a '.js' file corresponding to the supplied {@code Class}<br>
  * <b>i.e.:</b> {@code MyClass.js}
- * 
+ *
  * @author Sebastien Briquet - sebfz1
  *
  */
@@ -36,7 +36,7 @@ public class JavaScriptPackageHeaderItem extends JavaScriptReferenceHeaderItem
 
 	/**
 	 * Constructor
-	 * 
+	 *
 	 * @param scope the scope
 	 */
 	public JavaScriptPackageHeaderItem(Class<?> scope)
@@ -46,18 +46,18 @@ public class JavaScriptPackageHeaderItem extends JavaScriptReferenceHeaderItem
 
 	/**
 	 * Constructor
-	 * 
+	 *
 	 * @param scope the scope
 	 * @param function the function, i.e.: the name of the '.js' file without the extension
 	 */
 	public JavaScriptPackageHeaderItem(Class<?> scope, String function)
 	{
-		super(new JavaScriptResourceReference(scope, function + ".js"), null, function, false, null, null);
+		super(new JavaScriptResourceReference(scope, function + ".js"), null, function);
 	}
 
 	/**
 	 * Constructor
-	 * 
+	 *
 	 * @param scope the scope
 	 * @param variables the variable {@code Map} to supply to the file
 	 */
@@ -68,13 +68,13 @@ public class JavaScriptPackageHeaderItem extends JavaScriptReferenceHeaderItem
 
 	/**
 	 * Constructor
-	 * 
+	 *
 	 * @param scope the scope
 	 * @param function the function, i.e.: the name of the '.js' file without the extension
 	 * @param variables the variable {@code Map} to supply to the file
 	 */
 	public JavaScriptPackageHeaderItem(Class<?> scope, String function, Map<String, Object> variables)
 	{
-		super(new TextTemplateResourceReference(scope, function + ".js", Model.ofMap(variables)), null, function, false, null, null);
+		super(new TextTemplateResourceReference(scope, function + ".js", Model.ofMap(variables)), null, function);
 	}
 }

--- a/wicket-kendo-ui-culture/src/main/java/com/googlecode/wicket/kendo/ui/KendoCultureHeaderItem.java
+++ b/wicket-kendo-ui-culture/src/main/java/com/googlecode/wicket/kendo/ui/KendoCultureHeaderItem.java
@@ -17,7 +17,7 @@ import com.googlecode.wicket.kendo.ui.resource.KendoCultureResourceReference;
  * public void renderHead(IHeaderResponse response)
  * {
  * 	super.renderHead(response);
- * 	
+ *
  * 	response.render(new KendoCultureHeaderItem(KendoCulture.FR_FR));
  * }
  * </code></pre>
@@ -29,7 +29,7 @@ import com.googlecode.wicket.kendo.ui.resource.KendoCultureResourceReference;
  * 	kendo.culture('fr-FR');
  * &lt;/script&gt;
  * </code></pre>
- * 
+ *
  * @author Patrick Davids - Patrick1701
  *
  */
@@ -41,7 +41,7 @@ public class KendoCultureHeaderItem extends JavaScriptContentHeaderItem
 
 	/**
 	 * Constructor
-	 * 
+	 *
 	 * @param locale the {@link Locale}, ie: Locale.FRENCH
 	 */
 	public KendoCultureHeaderItem(Locale locale)
@@ -51,7 +51,7 @@ public class KendoCultureHeaderItem extends JavaScriptContentHeaderItem
 
 	/**
 	 * Constructor
-	 * 
+	 *
 	 * @param culture the {@link KendoCulture}
 	 */
 	public KendoCultureHeaderItem(KendoCulture culture)
@@ -61,12 +61,12 @@ public class KendoCultureHeaderItem extends JavaScriptContentHeaderItem
 
 	/**
 	 * Constructor
-	 * 
+	 *
 	 * @param culture the culture, ie: 'fr' or 'fr-FR'
 	 */
 	public KendoCultureHeaderItem(String culture)
 	{
-		super(String.format("kendo.culture('%s');", culture), "kendo-culture", null);
+		super(String.format("kendo.culture('%s');", culture), "kendo-culture");
 
 		this.culture = culture;
 	}
@@ -84,7 +84,7 @@ public class KendoCultureHeaderItem extends JavaScriptContentHeaderItem
 
 	/**
 	 * Gets a new {@link KendoCultureHeaderItem} from a {@code Locale} culture, with a fallback to the {@code Locale} 's language
-	 * 
+	 *
 	 * @param locale the {@code Locale}
 	 * @return a new {@link KendoCultureHeaderItem}
 	 */
@@ -100,7 +100,7 @@ public class KendoCultureHeaderItem extends JavaScriptContentHeaderItem
 
 	/**
 	 * Gets a new {@link KendoCultureHeaderItem} from the first valid specified culture
-	 * 
+	 *
 	 * @param cultures the array of cultures
 	 * @return a new {@link KendoCultureHeaderItem}
 	 */

--- a/wicket-kendo-ui-culture/src/main/java/com/googlecode/wicket/kendo/ui/KendoMessageHeaderItem.java
+++ b/wicket-kendo-ui-culture/src/main/java/com/googlecode/wicket/kendo/ui/KendoMessageHeaderItem.java
@@ -15,7 +15,7 @@ import com.googlecode.wicket.kendo.ui.resource.KendoMessageResourceReference;
  * public void renderHead(IHeaderResponse response)
  * {
  * 	super.renderHead(response);
- * 	
+ *
  * 	response.render(new KendoMessageHeaderItem(KendoMessage.FR_FR));
  * }
  * </code></pre>
@@ -24,7 +24,7 @@ import com.googlecode.wicket.kendo.ui.resource.KendoMessageResourceReference;
  * <pre><code>
  * &lt;script type="text/javascript" src="./resource/com.googlecode.wicket.kendo.ui.resource.KendoMessageResourceReference/messages/kendo.messages.fr-FR.js"&gt;&lt;/script&gt;
  * </code></pre>
- * 
+ *
  * @author Sebastien Briquet - sebfz1
  *
  */
@@ -34,7 +34,7 @@ public class KendoMessageHeaderItem extends JavaScriptReferenceHeaderItem
 
 	/**
 	 * Constructor
-	 * 
+	 *
 	 * @param locale the {@link Locale}, ie: Locale.FRENCH
 	 */
 	public KendoMessageHeaderItem(Locale locale)
@@ -44,7 +44,7 @@ public class KendoMessageHeaderItem extends JavaScriptReferenceHeaderItem
 
 	/**
 	 * Constructor
-	 * 
+	 *
 	 * @param message the {@link KendoMessage}
 	 */
 	public KendoMessageHeaderItem(KendoMessage message)
@@ -54,19 +54,19 @@ public class KendoMessageHeaderItem extends JavaScriptReferenceHeaderItem
 
 	/**
 	 * Constructor
-	 * 
+	 *
 	 * @param culture the culture, ie: 'fr-FR'
 	 */
 	public KendoMessageHeaderItem(String culture)
 	{
-		super(new KendoMessageResourceReference(culture), null, "kendo-messages", false, null, null);
+		super(new KendoMessageResourceReference(culture), null, "kendo-messages");
 	}
 
 	// Helpers //
 
 	/**
 	 * Gets a new {@link KendoMessageHeaderItem} from a {@link Locale} culture
-	 * 
+	 *
 	 * @param locale the {@code Locale}
 	 * @return a new {@link KendoMessageHeaderItem}
 	 */
@@ -82,7 +82,7 @@ public class KendoMessageHeaderItem extends JavaScriptReferenceHeaderItem
 
 	/**
 	 * Gets a new {@link KendoMessageHeaderItem} from the first valid specified culture
-	 * 
+	 *
 	 * @param cultures the array of cultures
 	 * @return a new {@link KendoMessageHeaderItem}
 	 */

--- a/wicket-kendo-ui/src/main/java/com/googlecode/wicket/kendo/ui/datatable/editor/KendoEditorHeaderItem.java
+++ b/wicket-kendo-ui/src/main/java/com/googlecode/wicket/kendo/ui/datatable/editor/KendoEditorHeaderItem.java
@@ -23,24 +23,24 @@ import org.apache.wicket.markup.head.JavaScriptContentHeaderItem;
  * Usage:<br>
  * <pre><code>
  * new PropertyColumn("Status", "status") {
- * 
+ *
  * 	public String getEditor()
  * 	{
  * 		return EDITOR_NAME;
  * 	}
  * }
- * 
+ *
  * class MyDataTable
  * {
  * 	public void renderHead(IHeaderResponse response)
  * 	{
  * 		super.renderHead(response);
- * 
+ *
  * 		response.render(new KendoEditorHeaderItem(new DropDownListEditor(EDITOR_NAME, MyEnum.values()), EDITOR_NAME));
  * 	}
  * }
  * </code></pre>
- * 
+ *
  * @author Sebastien Briquet - sebfz1
  *
  */
@@ -50,24 +50,12 @@ public class KendoEditorHeaderItem extends JavaScriptContentHeaderItem
 
 	/**
 	 * Constructor
-	 * 
+	 *
 	 * @param editor the {@link IKendoEditor}
 	 * @param id the id of the javascript element
 	 */
 	public KendoEditorHeaderItem(IKendoEditor editor, String id)
 	{
-		this(editor, id, null);
-	}
-
-	/**
-	 * Constructor
-	 * 
-	 * @param editor the {@link IKendoEditor}
-	 * @param id the id of the javascript element
-	 * @param condition the condition to use for Internet Explorer conditional comments. E.g. "IE 7".
-	 */
-	public KendoEditorHeaderItem(IKendoEditor editor, String id, String condition)
-	{
-		super(editor.toString(), id, condition);
+		super(editor.toString(), id);
 	}
 }

--- a/wicket-kendo-ui/src/main/java/com/googlecode/wicket/kendo/ui/form/datetime/DateTimePicker.java
+++ b/wicket-kendo-ui/src/main/java/com/googlecode/wicket/kendo/ui/form/datetime/DateTimePicker.java
@@ -146,7 +146,15 @@ public class DateTimePicker extends FormComponentPanel<Date> implements ITextFor
 		super(id, model);
 
 		this.locale = locale;
-		this.datePattern = datePattern;
+		// single 'y' is allowed in Java11, but *NOT* being work as expected while using with DateTimeFormatter
+		if (datePattern.contains("y") && !datePattern.contains("yy"))
+		{
+			this.datePattern = datePattern.replace("y", "yy");
+		}
+		else
+		{
+			this.datePattern = datePattern;
+		}
 		this.timePattern = timePattern;
 
 		this.setType(Date.class); // makes use of the converter
@@ -314,7 +322,7 @@ public class DateTimePicker extends FormComponentPanel<Date> implements ITextFor
 
 	/**
 	 * Gets a new {@link Date} {@link IConverter}.
-	 * 
+	 *
 	 * @param format the time format
 	 * @return the converter
 	 */
@@ -357,7 +365,7 @@ public class DateTimePicker extends FormComponentPanel<Date> implements ITextFor
 
 				this.setEnabled(DateTimePicker.this.isEnabled());
 			}
-			
+
 			// methods //
 
 			@Override

--- a/wicket-kendo-ui/src/main/java/com/googlecode/wicket/kendo/ui/utils/KendoDateTimeUtils.java
+++ b/wicket-kendo-ui/src/main/java/com/googlecode/wicket/kendo/ui/utils/KendoDateTimeUtils.java
@@ -84,11 +84,6 @@ public class KendoDateTimeUtils
 		{
 			converted = converted.replace("a", "aa");
 		}
-		// single 'y' is allowed in Java11, but *NOT* allowed in kendo
-		if (converted.contains("y") && !converted.contains("yy"))
-		{
-			converted = converted.replace("y", "yy");
-		}
 
 		for (int i = 0; i < chars_lenth; i++)
 		{


### PR DESCRIPTION
Hello @sebfz1,

It seems wicket-jquery-ui `9.0.0-M3.1` can't be used with `M4`
I did partial fix with 1 exception: `public abstract class UploadDialog extends AbstractFormDialog<FileUpload>`

`FileUpload` is no more `Serializable` so this dialog will require major changes
Could you please take a look at it and release new version? :))