### PR TITLE
add some flag that allows to block users selecting an option while a …

### DIFF
--- a/wicket-jquery-ui/src/main/java/com/googlecode/wicket/jquery/ui/form/autocomplete/AbstractAutoCompleteTextField.java
+++ b/wicket-jquery-ui/src/main/java/com/googlecode/wicket/jquery/ui/form/autocomplete/AbstractAutoCompleteTextField.java
@@ -1,0 +1,437 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.googlecode.wicket.jquery.ui.form.autocomplete;
+
+import com.googlecode.wicket.jquery.core.IJQueryWidget;
+import com.googlecode.wicket.jquery.core.JQueryBehavior;
+import com.googlecode.wicket.jquery.core.renderer.ITextRenderer;
+import com.googlecode.wicket.jquery.core.renderer.TextRenderer;
+import com.googlecode.wicket.jquery.core.template.IJQueryTemplate;
+import com.googlecode.wicket.jquery.core.utils.RequestCycleUtils;
+import com.googlecode.wicket.jquery.ui.template.JQueryTemplateBehavior;
+import org.apache.wicket.Component;
+import org.apache.wicket.ajax.AjaxRequestTarget;
+import org.apache.wicket.markup.ComponentTag;
+import org.apache.wicket.markup.head.IHeaderResponse;
+import org.apache.wicket.markup.head.JavaScriptHeaderItem;
+import org.apache.wicket.markup.head.OnDomReadyHeaderItem;
+import org.apache.wicket.markup.html.form.TextField;
+import org.apache.wicket.model.IModel;
+import org.apache.wicket.request.resource.JavaScriptResourceReference;
+import org.apache.wicket.util.convert.IConverter;
+
+import java.io.Serializable;
+import java.util.List;
+import java.util.Locale;
+
+/**
+ * Provides a jQuery auto-complete widget
+ *
+ * @param <T> the type of the model object
+ * @author Sebastien Briquet - sebfz1
+ */
+public abstract class AbstractAutoCompleteTextField<T extends Serializable, I> extends TextField<T> implements IJQueryWidget, IAutoCompleteListener<I> // NOSONAR
+{
+	private static final long serialVersionUID = 1L;
+
+	private static final JavaScriptResourceReference JS = new JavaScriptResourceReference(AbstractAutoCompleteTextField.class, "AutoCompleteTextField.js");
+
+	/**
+	 * Behavior that will be called when the user enters an input
+	 */
+	private AutoCompleteChoiceModelBehavior<T, I> choiceModelBehavior;
+
+	private final ITextRenderer<? super T> renderer;
+	private final IConverter<T> converter;
+
+	private final IAutoCompleteHandler<T, I> handler;
+
+	private final IJQueryTemplate template;
+	private JQueryTemplateBehavior templateBehavior = null;
+
+
+	/**
+	 * Setting this flag to true adds some extra protection at client side
+	 * preventing users to be able to select stale elements.
+	 */
+	private boolean preventSelectWhileQueryIsRunning = false;
+
+	private AutoCompleteBehavior<I> autoCompleteBehavior;
+
+	/**
+	 * Constructor
+	 *
+	 * @param id the markup id
+	 */
+	public AbstractAutoCompleteTextField(String id)
+	{
+		this(id, new TextRenderer<>());
+	}
+
+	/**
+	 * Constructor
+	 *
+	 * @param id the markup id
+	 * @param type the type of the bean. This parameter should be supplied for the internal converter ({@link #getConverter(Class)}) to be used.
+	 */
+	public AbstractAutoCompleteTextField(String id, Class<T> type)
+	{
+		this(id, new TextRenderer<>(), type);
+	}
+
+	/**
+	 * Constructor
+	 *
+	 * @param id the markup id
+	 * @param renderer the {@link ITextRenderer}
+	 */
+	public AbstractAutoCompleteTextField(String id, ITextRenderer<? super T> renderer)
+	{
+		this(id, renderer, null);
+	}
+
+	/**
+	 * Constructor
+	 *
+	 * @param id the markup id
+	 * @param renderer the {@link ITextRenderer}
+	 * @param type the type of the bean. This parameter should be supplied for the internal converter ({@link #getConverter(Class)}) to be used.
+	 */
+	public AbstractAutoCompleteTextField(String id, ITextRenderer<? super T> renderer, Class<T> type)
+	{
+		super(id, type);
+
+		this.renderer = renderer;
+		this.template = this.newTemplate();
+		this.converter = this.newConverter();
+		this.handler = this.newHandler();
+	}
+
+	/**
+	 * Constructor
+	 *
+	 * @param id the markup id
+	 * @param model the {@link IModel}
+	 */
+	public AbstractAutoCompleteTextField(String id, IModel<T> model)
+	{
+		this(id, model, new TextRenderer<>(), null);
+	}
+
+	/**
+	 * Constructor
+	 *
+	 * @param id the markup id
+	 * @param model the {@link IModel}
+	 * @param type the type of the bean. This parameter should be supplied for the internal converter ({@link #getConverter(Class)}) to be used.
+	 */
+	public AbstractAutoCompleteTextField(String id, IModel<T> model, Class<T> type)
+	{
+		this(id, model, new TextRenderer<>(), type);
+	}
+
+	/**
+	 * Constructor
+	 *
+	 * @param id the markup id
+	 * @param model the {@link IModel}
+	 * @param renderer the {@link ITextRenderer}
+	 */
+	public AbstractAutoCompleteTextField(String id, IModel<T> model, ITextRenderer<? super T> renderer)
+	{
+		this(id, model, renderer, null);
+	}
+
+	/**
+	 * Constructor
+	 *
+	 * @param id the markup id
+	 * @param model the {@link IModel}
+	 * @param renderer the {@link ITextRenderer}
+	 * @param type the type of the bean. This parameter should be supplied for the internal converter ({@link #getConverter(Class)}) to be used.
+	 */
+	public AbstractAutoCompleteTextField(String id, IModel<T> model, ITextRenderer<? super T> renderer, Class<T> type)
+	{
+		super(id, model, type);
+
+		this.renderer = renderer;
+		this.template = this.newTemplate();
+		this.converter = this.newConverter();
+		this.handler = this.newHandler();
+	}
+
+	// Methods //
+
+	@Override
+	protected final String getModelValue()
+	{
+		return this.renderer.getText(this.getModelObject()); // renderer cannot be null.
+	}
+
+	@Override
+	@SuppressWarnings("unchecked")
+	public <C> IConverter<C> getConverter(Class<C> type)
+	{
+		// TODO: manage String (property)model object in a better way
+		if (!String.class.isAssignableFrom(this.getType()))
+		{
+			if (type != null && type.isAssignableFrom(this.getType()))
+			{
+				return (IConverter<C>) this.converter;
+			}
+		}
+
+		return super.getConverter(type);
+	}
+
+	/**
+	 * Gets the template script token/id
+	 * 
+	 * @return the template script token/id
+	 */
+	public String getTemplateToken()
+	{
+		if (this.templateBehavior != null)
+		{
+			return this.templateBehavior.getToken();
+		}
+
+		return null;
+	}
+
+	// Properties //
+
+	/**
+	 * Gets the {@link ITextRenderer}
+	 *
+	 * @return the {@link ITextRenderer}
+	 */
+	public ITextRenderer<? super T> getRenderer()
+	{
+		return this.renderer;
+	}
+
+	// Events //
+
+	@Override
+	protected void onInitialize()
+	{
+		super.onInitialize();
+
+		this.choiceModelBehavior = this.newChoiceModelBehavior();
+		this.add(this.choiceModelBehavior);
+
+		this.add(JQueryWidget.newWidgetBehavior(this)); // cannot be in ctor as the markupId may be set manually afterward
+
+		if (this.template != null)
+		{
+			this.templateBehavior = new JQueryTemplateBehavior(this.template);
+			this.add(this.templateBehavior);
+		}
+	}
+
+	@Override
+	public void onConfigure(JQueryBehavior behavior)
+	{
+		// noop
+	}
+
+	@Override
+	public void onBeforeRender(JQueryBehavior behavior)
+	{
+	}
+
+	@Override
+	protected void onComponentTag(final ComponentTag tag)
+	{
+		super.onComponentTag(tag);
+
+		tag.put("autocomplete", "off"); // disable browser's autocomplete
+	}
+
+	@Override
+	public final void onSelect(AjaxRequestTarget target, I index)
+	{
+		T selected = handler.selectChoice(index);
+		if (selected != null) {
+			this.setModelObject(selected);
+			this.onSelected(target);
+		} else {
+			this.onSelectionFailed(target, index);
+		}
+	}
+
+	/**
+	 * Triggered when the user selects an item from results that matched its input
+	 *
+	 * @param target the {@link AjaxRequestTarget}
+	 */
+	protected void onSelected(AjaxRequestTarget target)
+	{
+	}
+
+	/**
+	 * Called when teh selection failed.
+	 *
+	 * @param target the {@link AjaxRequestTarget}
+	 * @param index the selected index
+	 */
+	protected void onSelectionFailed(AjaxRequestTarget target, I index)
+	{
+	}
+
+	// IJQueryWidget //
+
+	@Override
+	public JQueryBehavior newWidgetBehavior(String selector)
+	{
+		return autoCompleteBehavior = new AutoCompleteBehavior<>(selector, this) { // NOSONAR
+
+			private static final long serialVersionUID = 1L;
+
+			@Override
+			protected CharSequence getChoiceCallbackUrl()
+			{
+				return choiceModelBehavior.getCallbackUrl();
+			}
+
+			@Override
+			protected I indexToId(String index) {
+				return handler.indexToId(index);
+			}
+
+			@Override
+			protected String $()
+			{
+				if (templateBehavior != null)
+				{
+					// warning, the template text should be of the form <a>...</a> in order to work
+					String render = "jQuery('%s').data('ui-autocomplete')._renderItem = function( ul, item ) { " // lf
+							+ "var content = jQuery.tmpl(jQuery('#%s').html(), item);" // lf
+							+ "return jQuery('<li/>').data('ui-autocomplete-item', item).append(content).appendTo(ul);" // lf
+							+ "}";
+					
+					return super.$() + String.format(render, this.selector, templateBehavior.getToken());
+				}
+
+				return super.$();
+			}
+
+			@Override
+			public void onConfigure(Component component) {
+				super.onConfigure(component);
+				if (preventSelectWhileQueryIsRunning) {
+					// we define special functions in for handling select and fetch data
+					this.setOption("select", "function(request, response) {\n" + getVarName() + ".select(request, response); \n}");
+					if (this.isEnabled(component))
+					{
+						this.setOption("source",  "function(event, ui) {\n" + getVarName() + ".fetchItems(event, ui); \n}");
+					}
+				}
+			}
+		};
+	}
+
+	public void renderHead(IHeaderResponse response) {
+		if (preventSelectWhileQueryIsRunning) {
+			response.render(JavaScriptHeaderItem.forReference(JS));
+			// we create a prototype with the data we need
+			response.render(OnDomReadyHeaderItem.forScript(getVarName() + " = new WJQUI.AutoComplete('"
+					+ getMarkupId() + "','" + choiceModelBehavior.getCallbackUrl()
+					+ "', '" + autoCompleteBehavior.getOnSelectAjaxBehavior().getCallbackUrl() + "');"));
+		}
+	}
+
+	private String getVarName() {
+		return "window.aut_" + getMarkupId();
+	}
+
+	public AbstractAutoCompleteTextField<T, I> setPreventSelectWhileQueryIsRunning(boolean preventSelectWhileQueryIsRunning) {
+		this.preventSelectWhileQueryIsRunning = preventSelectWhileQueryIsRunning;
+		return this;
+	}
+
+
+	// Factories //
+
+	/**
+	 * Gets a new {@link IJQueryTemplate} to customize the rendering<br>
+	 * The {@link IJQueryTemplate#getText()} should return a template text of the form "&lt;a&gt;...&lt;/a&gt;".<br>
+	 * The properties used in the template text (ie: ${name}) should be identified in the list returned by {@link IJQueryTemplate#getTextProperties()}
+	 *
+	 * @return null by default
+	 */
+	protected IJQueryTemplate newTemplate()
+	{
+		return null;
+	}
+
+	protected abstract IAutoCompleteHandler<T, I> newHandler();
+
+	/**
+	 * Gets a new {@link IConverter}.<br>
+	 * Used when the form component is posted and the bean type has been supplied to the constructor.
+	 *
+	 * @return the {@link IConverter}
+	 */
+	private IConverter<T> newConverter()
+	{
+		return new IConverter<>() { // NOSONAR
+
+			private static final long serialVersionUID = 1L;
+
+			@Override
+			public T convertToObject(String value, Locale locale)
+			{
+				if (value != null && value.equals(AbstractAutoCompleteTextField.this.getModelValue()))
+				{
+					return AbstractAutoCompleteTextField.this.getModelObject();
+				}
+
+				return null; // if the TextField value (string) does not corresponds to the current object model (ie: user specific value), returns null.
+			}
+
+			@Override
+			public String convertToString(T value, Locale locale)
+			{
+				return AbstractAutoCompleteTextField.this.renderer.getText(value);
+			}
+		};
+	}
+
+	/**
+	 * Gets a new {@link AutoCompleteChoiceModelBehavior}
+	 *
+	 * @return the {@link AutoCompleteChoiceModelBehavior}
+	 */
+	private AutoCompleteChoiceModelBehavior<T, I> newChoiceModelBehavior()
+	{
+		return new AutoCompleteChoiceModelBehavior<>(this.renderer, this.template, this.handler) { // NOSONAR
+
+			private static final long serialVersionUID = 1L;
+			private static final String TERM = "term";
+
+			@Override
+			public List<T> getChoices()
+			{
+				final String input = RequestCycleUtils.getQueryParameterValue(TERM).toString();
+
+				return handler.getChoices(input);
+			}
+		};
+	}
+}

--- a/wicket-jquery-ui/src/main/java/com/googlecode/wicket/jquery/ui/form/autocomplete/AutoCompleteBehavior.java
+++ b/wicket-jquery-ui/src/main/java/com/googlecode/wicket/jquery/ui/form/autocomplete/AutoCompleteBehavior.java
@@ -33,13 +33,13 @@ import com.googlecode.wicket.jquery.ui.JQueryUIBehavior;
  *
  * @author Sebastien Briquet - sebfz1
  */
-public abstract class AutoCompleteBehavior extends JQueryUIBehavior implements IJQueryAjaxAware
+public abstract class AutoCompleteBehavior<I> extends JQueryUIBehavior implements IJQueryAjaxAware
 {
 	private static final long serialVersionUID = 1L;
 	public static final String METHOD = "autocomplete";
 
 	/** event listener */
-	private final IAutoCompleteListener listener;
+	private final IAutoCompleteListener<I> listener;
 
 	private JQueryAjaxBehavior onSelectAjaxBehavior = null;
 
@@ -49,7 +49,7 @@ public abstract class AutoCompleteBehavior extends JQueryUIBehavior implements I
 	 * @param selector the html selector (ie: "#myId")
 	 * @param listener the {@link IAutoCompleteListener}
 	 */
-	public AutoCompleteBehavior(String selector, IAutoCompleteListener listener)
+	public AutoCompleteBehavior(String selector, IAutoCompleteListener<I> listener)
 	{
 		this(selector, new Options(), listener);
 	}
@@ -61,7 +61,7 @@ public abstract class AutoCompleteBehavior extends JQueryUIBehavior implements I
 	 * @param options the {@link Options}
 	 * @param listener the {@link IAutoCompleteListener}
 	 */
-	public AutoCompleteBehavior(String selector, Options options, IAutoCompleteListener listener)
+	public AutoCompleteBehavior(String selector, Options options, IAutoCompleteListener<I> listener)
 	{
 		super(selector, METHOD, options);
 
@@ -111,9 +111,11 @@ public abstract class AutoCompleteBehavior extends JQueryUIBehavior implements I
 	{
 		if (event instanceof SelectEvent)
 		{
-			this.listener.onSelect(target, ((SelectEvent) event).getIndex());
+			this.listener.onSelect(target, indexToId(((SelectEvent) event).getIndex()));
 		}
 	}
+
+	protected abstract I indexToId(String index);
 
 	// Factories //
 
@@ -164,14 +166,14 @@ public abstract class AutoCompleteBehavior extends JQueryUIBehavior implements I
 	 */
 	protected static class SelectEvent extends JQueryEvent
 	{
-		private final int index;
+		private final String index;
 
 		public SelectEvent()
 		{
-			this.index = RequestCycleUtils.getQueryParameterValue("index").toInt(0);
+			this.index = RequestCycleUtils.getQueryParameterValue("index").toString(null);
 		}
 
-		public int getIndex()
+		public String getIndex()
 		{
 			return this.index;
 		}

--- a/wicket-jquery-ui/src/main/java/com/googlecode/wicket/jquery/ui/form/autocomplete/AutoCompleteBehavior.java
+++ b/wicket-jquery-ui/src/main/java/com/googlecode/wicket/jquery/ui/form/autocomplete/AutoCompleteBehavior.java
@@ -176,4 +176,8 @@ public abstract class AutoCompleteBehavior extends JQueryUIBehavior implements I
 			return this.index;
 		}
 	}
+
+	public JQueryAjaxBehavior getOnSelectAjaxBehavior() {
+		return onSelectAjaxBehavior;
+	}
 }

--- a/wicket-jquery-ui/src/main/java/com/googlecode/wicket/jquery/ui/form/autocomplete/AutoCompleteChoiceModelBehavior.java
+++ b/wicket-jquery-ui/src/main/java/com/googlecode/wicket/jquery/ui/form/autocomplete/AutoCompleteChoiceModelBehavior.java
@@ -33,18 +33,22 @@ import com.googlecode.wicket.jquery.core.template.IJQueryTemplate;
  * @param <T> the model object type
  * @author Sebastien Briquet - sebfz1
  */
-abstract class AutoCompleteChoiceModelBehavior<T> extends ChoiceModelBehavior<T>
+abstract class AutoCompleteChoiceModelBehavior<T, I> extends ChoiceModelBehavior<T>
 {
 	private static final long serialVersionUID = 1L;
 
-	public AutoCompleteChoiceModelBehavior(ITextRenderer<? super T> renderer)
+	private final IAutoCompleteHandler<T, I> handler;
+
+	public AutoCompleteChoiceModelBehavior(ITextRenderer<? super T> renderer, IAutoCompleteHandler<T, I> handler)
 	{
 		super(renderer);
+		this.handler = handler;
 	}
 
-	public AutoCompleteChoiceModelBehavior(ITextRenderer<? super T> renderer, IJQueryTemplate template)
+	public AutoCompleteChoiceModelBehavior(ITextRenderer<? super T> renderer, IJQueryTemplate template, IAutoCompleteHandler<T, I> handler)
 	{
 		super(renderer, template);
+		this.handler = handler;
 	}
 
 	@Override
@@ -61,7 +65,8 @@ abstract class AutoCompleteChoiceModelBehavior<T> extends ChoiceModelBehavior<T>
 
 				// ITextRenderer //
 				final JSONObject object = this.renderer.render(choice);
-				object.put("id", Integer.toString(index)); /* 'id' is a reserved word */
+				object.put("id", handler.getId(choice, index)); /* 'id' is a reserved word */
+				object.put("index", Integer.toString(index)); /* 'id' is a reserved word */
 				object.put("value", this.renderer.getText(choice)); /* 'value' is a reserved word */
 
 				// Additional properties (like template properties) //

--- a/wicket-jquery-ui/src/main/java/com/googlecode/wicket/jquery/ui/form/autocomplete/AutoCompleteTextField.java
+++ b/wicket-jquery-ui/src/main/java/com/googlecode/wicket/jquery/ui/form/autocomplete/AutoCompleteTextField.java
@@ -46,22 +46,78 @@ import com.googlecode.wicket.jquery.ui.template.JQueryTemplateBehavior;
  * @param <T> the type of the model object
  * @author Sebastien Briquet - sebfz1
  */
-public abstract class AutoCompleteTextField<T extends Serializable> extends TextField<T> implements IJQueryWidget, IAutoCompleteListener // NOSONAR
+public abstract class AutoCompleteTextField<T extends Serializable> extends AbstractAutoCompleteTextField<T, Integer>  // NOSONAR
 {
 	private static final long serialVersionUID = 1L;
 
-	private static final JavaScriptResourceReference JS = new JavaScriptResourceReference(AutoCompleteTextField.class, "AutoCompleteTextField.js");
 
-	/**
-	 * Behavior that will be called when the user enters an input
-	 */
-	private AutoCompleteChoiceModelBehavior<T> choiceModelBehavior;
+	private abstract class IndexIAutoCompleteHandler implements IAutoCompleteHandler<T, Integer> {
 
-	private final ITextRenderer<? super T> renderer;
-	private final IConverter<T> converter;
+		@Override
+		public Integer getId(T choice, int index)
+		{
+			return index;
+		}
 
-	private final IJQueryTemplate template;
-	private JQueryTemplateBehavior templateBehavior = null;
+		@Override
+		public Integer indexToId(String index) {
+			try {
+				return Integer.parseInt(index);
+			} catch (NumberFormatException e) {
+				return -1;
+			}
+
+		}
+
+		@Override
+		public T selectChoice(Integer index) {
+			if (-1 < index && index < choices.size())
+			{
+				return choices.get(index);
+			}
+			return null;
+		}
+	}
+
+	public AutoCompleteTextField(String id)
+	{
+		super(id);
+	}
+
+	public AutoCompleteTextField(String id, Class<T> type)
+	{
+		super(id, type);
+	}
+
+	public AutoCompleteTextField(String id, ITextRenderer<? super T> renderer)
+	{
+		super(id, renderer);
+	}
+
+	public AutoCompleteTextField(String id, ITextRenderer<? super T> renderer, Class<T> type)
+	{
+		super(id, renderer, type);
+	}
+
+	public AutoCompleteTextField(String id, IModel<T> model)
+	{
+		super(id, model);
+	}
+
+	public AutoCompleteTextField(String id, IModel<T> model, Class<T> type)
+	{
+		super(id, model, type);
+	}
+
+	public AutoCompleteTextField(String id, IModel<T> model, ITextRenderer<? super T> renderer)
+	{
+		super(id, model, renderer);
+	}
+
+	public AutoCompleteTextField(String id, IModel<T> model, TextRenderer<T> renderer, Class<T> tClass)
+	{
+		super(id, model, renderer, tClass);
+	}
 
 	/**
 	 * Cache of current choices, needed to retrieve the user selected object
@@ -69,204 +125,15 @@ public abstract class AutoCompleteTextField<T extends Serializable> extends Text
 	private List<T> choices;
 
 
-	/**
-	 * Setting this flag to true adds some extra protection at client side
-	 * preventing users to be able to select stale elements.
-	 */
-	private boolean preventSelectWhileQueryIsRunning = false;
-
-	private AutoCompleteBehavior autoCompleteBehavior;
-
-	/**
-	 * Constructor
-	 *
-	 * @param id the markup id
-	 */
-	public AutoCompleteTextField(String id)
-	{
-		this(id, new TextRenderer<T>(), null);
-	}
-
-	/**
-	 * Constructor
-	 *
-	 * @param id the markup id
-	 * @param type the type of the bean. This parameter should be supplied for the internal converter ({@link #getConverter(Class)}) to be used.
-	 */
-	public AutoCompleteTextField(String id, Class<T> type)
-	{
-		this(id, new TextRenderer<T>(), type);
-	}
-
-	/**
-	 * Constructor
-	 *
-	 * @param id the markup id
-	 * @param renderer the {@link ITextRenderer}
-	 */
-	public AutoCompleteTextField(String id, ITextRenderer<? super T> renderer)
-	{
-		this(id, renderer, null);
-	}
-
-	/**
-	 * Constructor
-	 *
-	 * @param id the markup id
-	 * @param renderer the {@link ITextRenderer}
-	 * @param type the type of the bean. This parameter should be supplied for the internal converter ({@link #getConverter(Class)}) to be used.
-	 */
-	public AutoCompleteTextField(String id, ITextRenderer<? super T> renderer, Class<T> type)
-	{
-		super(id, type);
-
-		this.renderer = renderer;
-		this.template = this.newTemplate();
-		this.converter = this.newConverter();
-	}
-
-	/**
-	 * Constructor
-	 *
-	 * @param id the markup id
-	 * @param model the {@link IModel}
-	 */
-	public AutoCompleteTextField(String id, IModel<T> model)
-	{
-		this(id, model, new TextRenderer<T>(), null);
-	}
-
-	/**
-	 * Constructor
-	 *
-	 * @param id the markup id
-	 * @param model the {@link IModel}
-	 * @param type the type of the bean. This parameter should be supplied for the internal converter ({@link #getConverter(Class)}) to be used.
-	 */
-	public AutoCompleteTextField(String id, IModel<T> model, Class<T> type)
-	{
-		this(id, model, new TextRenderer<T>(), type);
-	}
-
-	/**
-	 * Constructor
-	 *
-	 * @param id the markup id
-	 * @param model the {@link IModel}
-	 * @param renderer the {@link ITextRenderer}
-	 */
-	public AutoCompleteTextField(String id, IModel<T> model, ITextRenderer<? super T> renderer)
-	{
-		this(id, model, renderer, null);
-	}
-
-	/**
-	 * Constructor
-	 *
-	 * @param id the markup id
-	 * @param model the {@link IModel}
-	 * @param renderer the {@link ITextRenderer}
-	 * @param type the type of the bean. This parameter should be supplied for the internal converter ({@link #getConverter(Class)}) to be used.
-	 */
-	public AutoCompleteTextField(String id, IModel<T> model, ITextRenderer<? super T> renderer, Class<T> type)
-	{
-		super(id, model, type);
-
-		this.renderer = renderer;
-		this.template = this.newTemplate();
-		this.converter = this.newConverter();
-	}
-
-	// Methods //
-
-	/**
-	 * Call {@link #getChoices(String)} and cache the result<br>
-	 * Internal use only
-	 *
-	 * @param input String that represent the query
-	 * @return the list of choices
-	 */
-	private List<T> internalGetChoices(String input)
-	{
-		this.choices = this.getChoices(input);
-
-		return this.choices;
-	}
-
-	/**
-	 * Gets choices matching the provided input
-	 *
-	 * @param input String that represent the query
-	 * @return the list of choices
-	 */
-	protected abstract List<T> getChoices(String input);
-
 	@Override
-	protected final String getModelValue()
-	{
-		return this.renderer.getText(this.getModelObject()); // renderer cannot be null.
-	}
-
-	@Override
-	@SuppressWarnings("unchecked")
-	public <C> IConverter<C> getConverter(Class<C> type)
-	{
-		// TODO: manage String (property)model object in a better way
-		if (!String.class.isAssignableFrom(this.getType()))
-		{
-			if (type != null && type.isAssignableFrom(this.getType()))
-			{
-				return (IConverter<C>) this.converter;
+	protected IAutoCompleteHandler<T, Integer> newHandler() {
+		return new IndexIAutoCompleteHandler() {
+			@Override
+			public List<T> getChoices(String term) {
+				AutoCompleteTextField.this.choices = AutoCompleteTextField.this.getChoices(term);
+				return AutoCompleteTextField.this.choices;
 			}
-		}
-
-		return super.getConverter(type);
-	}
-
-	/**
-	 * Gets the template script token/id
-	 * 
-	 * @return the template script token/id
-	 */
-	public String getTemplateToken()
-	{
-		if (this.templateBehavior != null)
-		{
-			return this.templateBehavior.getToken();
-		}
-
-		return null;
-	}
-
-	// Properties //
-
-	/**
-	 * Gets the {@link ITextRenderer}
-	 *
-	 * @return the {@link ITextRenderer}
-	 */
-	public ITextRenderer<? super T> getRenderer()
-	{
-		return this.renderer;
-	}
-
-	// Events //
-
-	@Override
-	protected void onInitialize()
-	{
-		super.onInitialize();
-
-		this.choiceModelBehavior = this.newChoiceModelBehavior();
-		this.add(this.choiceModelBehavior);
-
-		this.add(JQueryWidget.newWidgetBehavior(this)); // cannot be in ctor as the markupId may be set manually afterward
-
-		if (this.template != null)
-		{
-			this.templateBehavior = new JQueryTemplateBehavior(this.template);
-			this.add(this.templateBehavior);
-		}
+		};
 	}
 
 	@Override
@@ -280,166 +147,19 @@ public abstract class AutoCompleteTextField<T extends Serializable> extends Text
 	{
 	}
 
+	/**
+	 * Gets choices matching the provided input
+	 *
+	 * @param input String that represent the query
+	 * @return the list of choices
+	 */
+	protected abstract List<T> getChoices(String input);
+
 	@Override
 	protected void onComponentTag(final ComponentTag tag)
 	{
 		super.onComponentTag(tag);
 
 		tag.put("autocomplete", "off"); // disable browser's autocomplete
-	}
-
-	@Override
-	public final void onSelect(AjaxRequestTarget target, int index)
-	{
-		if (-1 < index && index < this.choices.size())
-		{
-			T choice = this.choices.get(index);
-
-			this.setModelObject(choice);
-			this.onSelected(target);
-		}
-	}
-
-	/**
-	 * Triggered when the user selects an item from results that matched its input
-	 *
-	 * @param target the {@link AjaxRequestTarget}
-	 */
-	protected void onSelected(AjaxRequestTarget target)
-	{
-	}
-
-	// IJQueryWidget //
-
-	@Override
-	public JQueryBehavior newWidgetBehavior(String selector)
-	{
-		return autoCompleteBehavior = new AutoCompleteBehavior(selector, this) { // NOSONAR
-
-			private static final long serialVersionUID = 1L;
-
-			@Override
-			protected CharSequence getChoiceCallbackUrl()
-			{
-				return choiceModelBehavior.getCallbackUrl();
-			}
-
-			@Override
-			protected String $()
-			{
-				if (templateBehavior != null)
-				{
-					// warning, the template text should be of the form <a>...</a> in order to work
-					String render = "jQuery('%s').data('ui-autocomplete')._renderItem = function( ul, item ) { " // lf
-							+ "var content = jQuery.tmpl(jQuery('#%s').html(), item);" // lf
-							+ "return jQuery('<li/>').data('ui-autocomplete-item', item).append(content).appendTo(ul);" // lf
-							+ "}";
-					
-					return super.$() + String.format(render, this.selector, templateBehavior.getToken());
-				}
-
-				return super.$();
-			}
-
-			@Override
-			public void onConfigure(Component component) {
-				super.onConfigure(component);
-				if (preventSelectWhileQueryIsRunning) {
-					// we define special functions in for handling select and fetch data
-					this.setOption("select", "function(request, response) {\n" + getVarName() + ".select(request, response); \n}");
-					if (this.isEnabled(component))
-					{
-						this.setOption("source",  "function(event, ui) {\n" + getVarName() + ".fetchItems(event, ui); \n}");
-					}
-				}
-			}
-		};
-	}
-
-	public void renderHead(IHeaderResponse response) {
-		if (preventSelectWhileQueryIsRunning) {
-			response.render(JavaScriptHeaderItem.forReference(JS));
-			// we create a prototype with the data we need
-			response.render(OnDomReadyHeaderItem.forScript(getVarName() + " = new WJQUI.AutoComplete('"
-					+ getMarkupId() + "','" + choiceModelBehavior.getCallbackUrl()
-					+ "', '" + autoCompleteBehavior.getOnSelectAjaxBehavior().getCallbackUrl() + "');"));
-		}
-	}
-
-	private String getVarName() {
-		return "window.aut_" + getMarkupId();
-	}
-
-	public AutoCompleteTextField<T> setPreventSelectWhileQueryIsRunning(boolean preventSelectWhileQueryIsRunning) {
-		this.preventSelectWhileQueryIsRunning = preventSelectWhileQueryIsRunning;
-		return this;
-	}
-
-
-	// Factories //
-
-	/**
-	 * Gets a new {@link IJQueryTemplate} to customize the rendering<br>
-	 * The {@link IJQueryTemplate#getText()} should return a template text of the form "&lt;a&gt;...&lt;/a&gt;".<br>
-	 * The properties used in the template text (ie: ${name}) should be identified in the list returned by {@link IJQueryTemplate#getTextProperties()}
-	 *
-	 * @return null by default
-	 */
-	protected IJQueryTemplate newTemplate()
-	{
-		return null;
-	}
-
-	/**
-	 * Gets a new {@link IConverter}.<br>
-	 * Used when the form component is posted and the bean type has been supplied to the constructor.
-	 *
-	 * @return the {@link IConverter}
-	 */
-	private IConverter<T> newConverter()
-	{
-		return new IConverter<T>() { // NOSONAR
-
-			private static final long serialVersionUID = 1L;
-
-			@Override
-			public T convertToObject(String value, Locale locale)
-			{
-				if (value != null && value.equals(AutoCompleteTextField.this.getModelValue()))
-				{
-					return AutoCompleteTextField.this.getModelObject();
-				}
-
-				return null; // if the TextField value (string) does not corresponds to the current object model (ie: user specific value), returns null.
-			}
-
-			@Override
-			public String convertToString(T value, Locale locale)
-			{
-				return AutoCompleteTextField.this.renderer.getText(value);
-			}
-		};
-	}
-
-	/**
-	 * Gets a new {@link AutoCompleteChoiceModelBehavior}
-	 *
-	 * @return the {@link AutoCompleteChoiceModelBehavior}
-	 */
-	private AutoCompleteChoiceModelBehavior<T> newChoiceModelBehavior()
-	{
-		return new AutoCompleteChoiceModelBehavior<T>(this.renderer, this.template) { // NOSONAR
-
-			private static final long serialVersionUID = 1L;
-			private static final String TERM = "term";
-
-			@Override
-			public List<T> getChoices()
-			{
-				final String input = RequestCycleUtils.getQueryParameterValue(TERM).toString();
-
-				return AutoCompleteTextField.this.internalGetChoices(input);
-			}
-		};
 	}
 }

--- a/wicket-jquery-ui/src/main/java/com/googlecode/wicket/jquery/ui/form/autocomplete/IAutoCompleteHandler.java
+++ b/wicket-jquery-ui/src/main/java/com/googlecode/wicket/jquery/ui/form/autocomplete/IAutoCompleteHandler.java
@@ -1,0 +1,62 @@
+package com.googlecode.wicket.jquery.ui.form.autocomplete;
+
+import java.util.List;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * This interface defines a way to use autocomplete based in other selection criteria not necessarily the index
+ *
+ * @param <T> The type of bean
+ * @param <ID> The type of the ID generate
+ */
+public interface IAutoCompleteHandler<T, ID>
+{
+    /**
+     * Returns a unique id for a choice with a given index.
+     *
+     * @param choice The choice
+     * @param index The index
+     *
+     * @return a given ID
+     */
+    ID getId(T choice, int index);
+
+    /**
+     * Converts a client side "index" into an ID.
+     *
+     * @param index The index
+     * @return the server side ID corresponding to the index.
+     */
+    ID indexToId(String index);
+
+    /**
+     * @param term The filtering term
+     * @return A list of choices matching the term.
+     */
+    List<T> getChoices(String term);
+
+
+    /**
+     * Selects the choice for the given ID (if any still exists)
+     *
+     * @param id The ID
+     * @return The selected choice.
+     */
+    T selectChoice(ID id);
+}

--- a/wicket-jquery-ui/src/main/java/com/googlecode/wicket/jquery/ui/form/autocomplete/IAutoCompleteListener.java
+++ b/wicket-jquery-ui/src/main/java/com/googlecode/wicket/jquery/ui/form/autocomplete/IAutoCompleteListener.java
@@ -25,7 +25,7 @@ import org.apache.wicket.util.io.IClusterable;
  * @author Sebastien Briquet - sebfz1
  *
  */
-public interface IAutoCompleteListener extends IClusterable
+public interface IAutoCompleteListener<I> extends IClusterable
 {
 	/**
 	 * Triggered when a selection has been made
@@ -33,5 +33,5 @@ public interface IAutoCompleteListener extends IClusterable
 	 * @param target the {@link AjaxRequestTarget}
 	 * @param index the index of the selected item
 	 */
-	void onSelect(AjaxRequestTarget target, int index);
+	void onSelect(AjaxRequestTarget target, I index);
 }

--- a/wicket-jquery-ui/src/main/resources/com/googlecode/wicket/jquery/ui/form/autocomplete/AutoCompleteTextField.js
+++ b/wicket-jquery-ui/src/main/resources/com/googlecode/wicket/jquery/ui/form/autocomplete/AutoCompleteTextField.js
@@ -1,0 +1,48 @@
+var WJQUI = WJQUI || {};
+
+WJQUI.AutoComplete = function(id, choicesUrl, selectUrl) {
+    this.id = id;
+    this.choicesUrl = choicesUrl;
+    this.selectUrl = selectUrl;
+}
+
+// we fetch items here
+WJQUI.AutoComplete.prototype.fetchItems = function(request, response) {
+    if (this.xhr) {
+        // if there is a request being made, then stop it
+        this.xhr.abort();
+    }
+    const self = this;
+    this.xhr = $.ajax( {
+        url: this.choicesUrl,
+        data: {'term': request.term},
+        dataType: "json",
+        success: function( data ) {
+            response( data );
+            self.xhr = null;
+        },
+        error: function() {
+            response( [] );
+            self.xhr = null;
+        }
+    } );
+}
+
+// function executed in order to select an element in dropdown
+WJQUI.AutoComplete.prototype.select = function (event, ui) {
+    // in case the user selects something while a new request is running
+    if (this.xhr) {
+        // then we cancel user selection as we could select something
+        // at client side that corresponds to something else at server side
+        // (after second request for data is processed at server side)
+        event.preventDefault();
+        event.stopPropagation();
+        return;
+    }
+    const attrs = {
+        "u": this.selectUrl,
+        "c": this.id,
+        "ep": [{"name": "index", "value": ui.item.id}]
+    };
+    Wicket.Ajax.ajax(attrs);
+}


### PR DESCRIPTION
add some flag that allows to block users selecting an option while a query is in process

@sebfz1 this PR is based on some changes I did for our project. We will soon test this in our pre-production environment and see if that fixes the issue we are experiencing there. The issue being:

1. Users select something at client side
2. Wrong selection is done in server because user selected sate data in client and a request was sent to server side that didn't return items yet.

This PR tries to prevent the user from being able to select something while there is a request to server. I have added this via a flag set to false so that previous behavior is set to be default


