### PR TITLE
Issue #353: Upgrade to Wicket 10

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
 
 	<groupId>com.googlecode.wicket-jquery-ui</groupId>
 	<artifactId>wicket-jquery-ui-parent</artifactId>
-	<version>9.11.1-SNAPSHOT</version>
+	<version>10.0.0-SNAPSHOT</version>
 	<packaging>pom</packaging>
 
 	<licenses>
@@ -44,7 +44,7 @@
 	</scm>
 
 	<properties>
-		<wicket.version>9.11.0</wicket.version>
+		<wicket.version>10.0.0-M1-SNAPSHOT</wicket.version>
 		<owasp-sanitizer.version>20220608.1</owasp-sanitizer.version>
 		<junit.version>5.8.1</junit.version>
 		<!-- allowed values: R7, 1.0, 1.5, 2.0 or none -->
@@ -80,6 +80,11 @@
 	<build>
 		<pluginManagement>
 			<plugins>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-war-plugin</artifactId>
+          <version>3.3.2</version>
+        </plugin>
 				<plugin>
 					<groupId>org.apache.felix</groupId>
 					<artifactId>maven-bundle-plugin</artifactId>

--- a/wicket-jquery-ui-calendar/pom.xml
+++ b/wicket-jquery-ui-calendar/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>com.googlecode.wicket-jquery-ui</groupId>
 		<artifactId>wicket-jquery-ui-parent</artifactId>
-		<version>9.11.1-SNAPSHOT</version>
+		<version>10.0.0-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>wicket-jquery-ui-calendar</artifactId>
@@ -22,7 +22,7 @@
 		<dependency>
 			<groupId>com.googlecode.wicket-jquery-ui</groupId>
 			<artifactId>wicket-jquery-ui-core</artifactId>
-			<version>9.11.1-SNAPSHOT</version>
+			<version>10.0.0-SNAPSHOT</version>
 		</dependency>
 
 		<!-- WICKET DEPENDENCIES -->

--- a/wicket-jquery-ui-core/pom.xml
+++ b/wicket-jquery-ui-core/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>com.googlecode.wicket-jquery-ui</groupId>
 		<artifactId>wicket-jquery-ui-parent</artifactId>
-		<version>9.11.1-SNAPSHOT</version>
+		<version>10.0.0-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>wicket-jquery-ui-core</artifactId>

--- a/wicket-jquery-ui-plugins/pom.xml
+++ b/wicket-jquery-ui-plugins/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>com.googlecode.wicket-jquery-ui</groupId>
 		<artifactId>wicket-jquery-ui-parent</artifactId>
-		<version>9.11.1-SNAPSHOT</version>
+		<version>10.0.0-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>wicket-jquery-ui-plugins</artifactId>
@@ -22,7 +22,7 @@
 		<dependency>
 			<groupId>com.googlecode.wicket-jquery-ui</groupId>
 			<artifactId>wicket-jquery-ui-core</artifactId>
-			<version>9.11.1-SNAPSHOT</version>
+			<version>10.0.0-SNAPSHOT</version>
 		</dependency>
 
 		<!-- WICKET DEPENDENCIES -->

--- a/wicket-jquery-ui-samples/pom.xml
+++ b/wicket-jquery-ui-samples/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>com.googlecode.wicket-jquery-ui</groupId>
 		<artifactId>wicket-jquery-ui-parent</artifactId>
-		<version>9.11.1-SNAPSHOT</version>
+		<version>10.0.0-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>wicket-jquery-ui-samples</artifactId>
@@ -24,39 +24,39 @@
 		<dependency>
 			<groupId>com.googlecode.wicket-jquery-ui</groupId>
 			<artifactId>wicket-jquery-ui</artifactId>
-			<version>9.11.1-SNAPSHOT</version>
+			<version>10.0.0-SNAPSHOT</version>
 		</dependency>
 		<dependency>
 			<groupId>com.googlecode.wicket-jquery-ui</groupId>
 			<artifactId>wicket-jquery-ui-theme-base</artifactId>
-			<version>9.11.1-SNAPSHOT</version>
+			<version>10.0.0-SNAPSHOT</version>
 		</dependency>
 		<dependency>
 			<groupId>com.googlecode.wicket-jquery-ui</groupId>
 			<artifactId>wicket-jquery-ui-calendar</artifactId>
-			<version>9.11.1-SNAPSHOT</version>
+			<version>10.0.0-SNAPSHOT</version>
 		</dependency>
 		<dependency>
 			<groupId>com.googlecode.wicket-jquery-ui</groupId>
 			<artifactId>wicket-jquery-ui-plugins</artifactId>
-			<version>9.11.1-SNAPSHOT</version>
+			<version>10.0.0-SNAPSHOT</version>
 		</dependency>
 
 		<!-- KENDO-UI DEPENDENCIES -->
 		<dependency>
 			<groupId>com.googlecode.wicket-jquery-ui</groupId>
 			<artifactId>wicket-kendo-ui</artifactId>
-			<version>9.11.1-SNAPSHOT</version>
+			<version>10.0.0-SNAPSHOT</version>
 		</dependency>
 		<dependency>
 			<groupId>com.googlecode.wicket-jquery-ui</groupId>
 			<artifactId>wicket-kendo-ui-culture</artifactId>
-			<version>9.11.1-SNAPSHOT</version>
+			<version>10.0.0-SNAPSHOT</version>
 		</dependency>
 		<dependency>
 			<groupId>com.googlecode.wicket-jquery-ui</groupId>
 			<artifactId>wicket-kendo-ui-theme-default</artifactId>
-			<version>9.11.1-SNAPSHOT</version>
+			<version>10.0.0-SNAPSHOT</version>
 		</dependency>
 
 		<!-- WICKET DEPENDENCIES -->

--- a/wicket-jquery-ui-themes/pom.xml
+++ b/wicket-jquery-ui-themes/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>com.googlecode.wicket-jquery-ui</groupId>
 		<artifactId>wicket-jquery-ui-parent</artifactId>
-		<version>9.11.1-SNAPSHOT</version>
+		<version>10.0.0-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>wicket-jquery-ui-themes</artifactId>
@@ -18,7 +18,7 @@
 		<dependency>
 			<groupId>com.googlecode.wicket-jquery-ui</groupId>
 			<artifactId>wicket-jquery-ui</artifactId>
-			<version>9.11.1-SNAPSHOT</version>
+			<version>10.0.0-SNAPSHOT</version>
 			<scope>provided</scope>
 		</dependency>	
 		<!-- WICKET DEPENDENCIES -->

--- a/wicket-jquery-ui-themes/theme-base/pom.xml
+++ b/wicket-jquery-ui-themes/theme-base/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>com.googlecode.wicket-jquery-ui</groupId>
 		<artifactId>wicket-jquery-ui-themes</artifactId>
-		<version>9.11.1-SNAPSHOT</version>
+		<version>10.0.0-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>wicket-jquery-ui-theme-base</artifactId>

--- a/wicket-jquery-ui-themes/theme-black-tie/pom.xml
+++ b/wicket-jquery-ui-themes/theme-black-tie/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>com.googlecode.wicket-jquery-ui</groupId>
 		<artifactId>wicket-jquery-ui-themes</artifactId>
-		<version>9.11.1-SNAPSHOT</version>
+		<version>10.0.0-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>wicket-jquery-ui-theme-blacktie</artifactId>

--- a/wicket-jquery-ui-themes/theme-blitzer/pom.xml
+++ b/wicket-jquery-ui-themes/theme-blitzer/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>com.googlecode.wicket-jquery-ui</groupId>
 		<artifactId>wicket-jquery-ui-themes</artifactId>
-		<version>9.11.1-SNAPSHOT</version>
+		<version>10.0.0-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>wicket-jquery-ui-theme-blitzer</artifactId>

--- a/wicket-jquery-ui-themes/theme-cupertino/pom.xml
+++ b/wicket-jquery-ui-themes/theme-cupertino/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>com.googlecode.wicket-jquery-ui</groupId>
 		<artifactId>wicket-jquery-ui-themes</artifactId>
-		<version>9.11.1-SNAPSHOT</version>
+		<version>10.0.0-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>wicket-jquery-ui-theme-cupertino</artifactId>

--- a/wicket-jquery-ui-themes/theme-dark-hive/pom.xml
+++ b/wicket-jquery-ui-themes/theme-dark-hive/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>com.googlecode.wicket-jquery-ui</groupId>
 		<artifactId>wicket-jquery-ui-themes</artifactId>
-		<version>9.11.1-SNAPSHOT</version>
+		<version>10.0.0-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>wicket-jquery-ui-theme-darkhive</artifactId>

--- a/wicket-jquery-ui-themes/theme-dot-luv/pom.xml
+++ b/wicket-jquery-ui-themes/theme-dot-luv/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>com.googlecode.wicket-jquery-ui</groupId>
 		<artifactId>wicket-jquery-ui-themes</artifactId>
-		<version>9.11.1-SNAPSHOT</version>
+		<version>10.0.0-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>wicket-jquery-ui-theme-dotluv</artifactId>

--- a/wicket-jquery-ui-themes/theme-eggplant/pom.xml
+++ b/wicket-jquery-ui-themes/theme-eggplant/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>com.googlecode.wicket-jquery-ui</groupId>
 		<artifactId>wicket-jquery-ui-themes</artifactId>
-		<version>9.11.1-SNAPSHOT</version>
+		<version>10.0.0-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>wicket-jquery-ui-theme-eggplant</artifactId>

--- a/wicket-jquery-ui-themes/theme-excite-bike/pom.xml
+++ b/wicket-jquery-ui-themes/theme-excite-bike/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>com.googlecode.wicket-jquery-ui</groupId>
 		<artifactId>wicket-jquery-ui-themes</artifactId>
-		<version>9.11.1-SNAPSHOT</version>
+		<version>10.0.0-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>wicket-jquery-ui-theme-excitebike</artifactId>

--- a/wicket-jquery-ui-themes/theme-flick/pom.xml
+++ b/wicket-jquery-ui-themes/theme-flick/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>com.googlecode.wicket-jquery-ui</groupId>
 		<artifactId>wicket-jquery-ui-themes</artifactId>
-		<version>9.11.1-SNAPSHOT</version>
+		<version>10.0.0-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>wicket-jquery-ui-theme-flick</artifactId>

--- a/wicket-jquery-ui-themes/theme-hot-sneaks/pom.xml
+++ b/wicket-jquery-ui-themes/theme-hot-sneaks/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>com.googlecode.wicket-jquery-ui</groupId>
 		<artifactId>wicket-jquery-ui-themes</artifactId>
-		<version>9.11.1-SNAPSHOT</version>
+		<version>10.0.0-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>wicket-jquery-ui-theme-hotsneaks</artifactId>

--- a/wicket-jquery-ui-themes/theme-humanity/pom.xml
+++ b/wicket-jquery-ui-themes/theme-humanity/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>com.googlecode.wicket-jquery-ui</groupId>
 		<artifactId>wicket-jquery-ui-themes</artifactId>
-		<version>9.11.1-SNAPSHOT</version>
+		<version>10.0.0-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>wicket-jquery-ui-theme-humanity</artifactId>

--- a/wicket-jquery-ui-themes/theme-le-frog/pom.xml
+++ b/wicket-jquery-ui-themes/theme-le-frog/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>com.googlecode.wicket-jquery-ui</groupId>
 		<artifactId>wicket-jquery-ui-themes</artifactId>
-		<version>9.11.1-SNAPSHOT</version>
+		<version>10.0.0-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>wicket-jquery-ui-theme-lefrog</artifactId>

--- a/wicket-jquery-ui-themes/theme-mint-choc/pom.xml
+++ b/wicket-jquery-ui-themes/theme-mint-choc/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>com.googlecode.wicket-jquery-ui</groupId>
 		<artifactId>wicket-jquery-ui-themes</artifactId>
-		<version>9.11.1-SNAPSHOT</version>
+		<version>10.0.0-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>wicket-jquery-ui-theme-mintchoc</artifactId>

--- a/wicket-jquery-ui-themes/theme-overcast/pom.xml
+++ b/wicket-jquery-ui-themes/theme-overcast/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>com.googlecode.wicket-jquery-ui</groupId>
 		<artifactId>wicket-jquery-ui-themes</artifactId>
-		<version>9.11.1-SNAPSHOT</version>
+		<version>10.0.0-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>wicket-jquery-ui-theme-overcast</artifactId>

--- a/wicket-jquery-ui-themes/theme-pepper-grinder/pom.xml
+++ b/wicket-jquery-ui-themes/theme-pepper-grinder/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>com.googlecode.wicket-jquery-ui</groupId>
 		<artifactId>wicket-jquery-ui-themes</artifactId>
-		<version>9.11.1-SNAPSHOT</version>
+		<version>10.0.0-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>wicket-jquery-ui-theme-peppergrinder</artifactId>

--- a/wicket-jquery-ui-themes/theme-redmond/pom.xml
+++ b/wicket-jquery-ui-themes/theme-redmond/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>com.googlecode.wicket-jquery-ui</groupId>
 		<artifactId>wicket-jquery-ui-themes</artifactId>
-		<version>9.11.1-SNAPSHOT</version>
+		<version>10.0.0-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>wicket-jquery-ui-theme-redmond</artifactId>

--- a/wicket-jquery-ui-themes/theme-smoothness/pom.xml
+++ b/wicket-jquery-ui-themes/theme-smoothness/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>com.googlecode.wicket-jquery-ui</groupId>
 		<artifactId>wicket-jquery-ui-themes</artifactId>
-		<version>9.11.1-SNAPSHOT</version>
+		<version>10.0.0-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>wicket-jquery-ui-theme-smoothness</artifactId>

--- a/wicket-jquery-ui-themes/theme-south-street/pom.xml
+++ b/wicket-jquery-ui-themes/theme-south-street/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>com.googlecode.wicket-jquery-ui</groupId>
 		<artifactId>wicket-jquery-ui-themes</artifactId>
-		<version>9.11.1-SNAPSHOT</version>
+		<version>10.0.0-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>wicket-jquery-ui-theme-southstreet</artifactId>

--- a/wicket-jquery-ui-themes/theme-start/pom.xml
+++ b/wicket-jquery-ui-themes/theme-start/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>com.googlecode.wicket-jquery-ui</groupId>
 		<artifactId>wicket-jquery-ui-themes</artifactId>
-		<version>9.11.1-SNAPSHOT</version>
+		<version>10.0.0-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>wicket-jquery-ui-theme-start</artifactId>

--- a/wicket-jquery-ui-themes/theme-sunny/pom.xml
+++ b/wicket-jquery-ui-themes/theme-sunny/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>com.googlecode.wicket-jquery-ui</groupId>
 		<artifactId>wicket-jquery-ui-themes</artifactId>
-		<version>9.11.1-SNAPSHOT</version>
+		<version>10.0.0-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>wicket-jquery-ui-theme-sunny</artifactId>

--- a/wicket-jquery-ui-themes/theme-swanky-purse/pom.xml
+++ b/wicket-jquery-ui-themes/theme-swanky-purse/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>com.googlecode.wicket-jquery-ui</groupId>
 		<artifactId>wicket-jquery-ui-themes</artifactId>
-		<version>9.11.1-SNAPSHOT</version>
+		<version>10.0.0-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>wicket-jquery-ui-theme-swankypurse</artifactId>

--- a/wicket-jquery-ui-themes/theme-trontastic/pom.xml
+++ b/wicket-jquery-ui-themes/theme-trontastic/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>com.googlecode.wicket-jquery-ui</groupId>
 		<artifactId>wicket-jquery-ui-themes</artifactId>
-		<version>9.11.1-SNAPSHOT</version>
+		<version>10.0.0-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>wicket-jquery-ui-theme-trontastic</artifactId>

--- a/wicket-jquery-ui-themes/theme-ui-darkness/pom.xml
+++ b/wicket-jquery-ui-themes/theme-ui-darkness/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>com.googlecode.wicket-jquery-ui</groupId>
 		<artifactId>wicket-jquery-ui-themes</artifactId>
-		<version>9.11.1-SNAPSHOT</version>
+		<version>10.0.0-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>wicket-jquery-ui-theme-uidarkness</artifactId>

--- a/wicket-jquery-ui-themes/theme-ui-lightness/pom.xml
+++ b/wicket-jquery-ui-themes/theme-ui-lightness/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>com.googlecode.wicket-jquery-ui</groupId>
 		<artifactId>wicket-jquery-ui-themes</artifactId>
-		<version>9.11.1-SNAPSHOT</version>
+		<version>10.0.0-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>wicket-jquery-ui-theme-uilightness</artifactId>

--- a/wicket-jquery-ui-themes/theme-vader/pom.xml
+++ b/wicket-jquery-ui-themes/theme-vader/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>com.googlecode.wicket-jquery-ui</groupId>
 		<artifactId>wicket-jquery-ui-themes</artifactId>
-		<version>9.11.1-SNAPSHOT</version>
+		<version>10.0.0-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>wicket-jquery-ui-theme-vader</artifactId>

--- a/wicket-jquery-ui/pom.xml
+++ b/wicket-jquery-ui/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>com.googlecode.wicket-jquery-ui</groupId>
 		<artifactId>wicket-jquery-ui-parent</artifactId>
-		<version>9.11.1-SNAPSHOT</version>
+		<version>10.0.0-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>wicket-jquery-ui</artifactId>
@@ -22,7 +22,7 @@
 		<dependency>
 			<groupId>com.googlecode.wicket-jquery-ui</groupId>
 			<artifactId>wicket-jquery-ui-core</artifactId>
-			<version>9.11.1-SNAPSHOT</version>
+			<version>10.0.0-SNAPSHOT</version>
 		</dependency>
 
 		<!-- WICKET DEPENDENCIES -->

--- a/wicket-kendo-ui-culture/pom.xml
+++ b/wicket-kendo-ui-culture/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>com.googlecode.wicket-jquery-ui</groupId>
 		<artifactId>wicket-jquery-ui-parent</artifactId>
-		<version>9.11.1-SNAPSHOT</version>
+		<version>10.0.0-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>wicket-kendo-ui-culture</artifactId>
@@ -23,7 +23,7 @@
 		<dependency>
 			<groupId>com.googlecode.wicket-jquery-ui</groupId>
 			<artifactId>wicket-kendo-ui</artifactId>
-			<version>9.11.1-SNAPSHOT</version>
+			<version>10.0.0-SNAPSHOT</version>
 		</dependency>
 
 		<!-- WICKET DEPENDENCIES -->

--- a/wicket-kendo-ui-themes/pom.xml
+++ b/wicket-kendo-ui-themes/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>com.googlecode.wicket-jquery-ui</groupId>
 		<artifactId>wicket-jquery-ui-parent</artifactId>
-		<version>9.11.1-SNAPSHOT</version>
+		<version>10.0.0-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>wicket-kendo-ui-themes</artifactId>

--- a/wicket-kendo-ui-themes/theme-black/pom.xml
+++ b/wicket-kendo-ui-themes/theme-black/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>com.googlecode.wicket-jquery-ui</groupId>
 		<artifactId>wicket-kendo-ui-themes</artifactId>
-		<version>9.11.1-SNAPSHOT</version>
+		<version>10.0.0-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>wicket-kendo-ui-theme-black</artifactId>
@@ -22,7 +22,7 @@
 		<dependency>
 			<groupId>com.googlecode.wicket-jquery-ui</groupId>
 			<artifactId>wicket-kendo-ui</artifactId>
-			<version>9.11.1-SNAPSHOT</version>
+			<version>10.0.0-SNAPSHOT</version>
 			<scope>provided</scope>
 		</dependency>
 

--- a/wicket-kendo-ui-themes/theme-blue-opal/pom.xml
+++ b/wicket-kendo-ui-themes/theme-blue-opal/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>com.googlecode.wicket-jquery-ui</groupId>
 		<artifactId>wicket-kendo-ui-themes</artifactId>
-		<version>9.11.1-SNAPSHOT</version>
+		<version>10.0.0-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>wicket-kendo-ui-theme-blueopal</artifactId>
@@ -22,7 +22,7 @@
 		<dependency>
 			<groupId>com.googlecode.wicket-jquery-ui</groupId>
 			<artifactId>wicket-kendo-ui</artifactId>
-			<version>9.11.1-SNAPSHOT</version>
+			<version>10.0.0-SNAPSHOT</version>
 			<scope>provided</scope>
 		</dependency>
 

--- a/wicket-kendo-ui-themes/theme-bootstrap/pom.xml
+++ b/wicket-kendo-ui-themes/theme-bootstrap/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>com.googlecode.wicket-jquery-ui</groupId>
 		<artifactId>wicket-kendo-ui-themes</artifactId>
-		<version>9.11.1-SNAPSHOT</version>
+		<version>10.0.0-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>wicket-kendo-ui-theme-bootstrap</artifactId>
@@ -22,7 +22,7 @@
 		<dependency>
 			<groupId>com.googlecode.wicket-jquery-ui</groupId>
 			<artifactId>wicket-kendo-ui</artifactId>
-			<version>9.11.1-SNAPSHOT</version>
+			<version>10.0.0-SNAPSHOT</version>
 			<scope>provided</scope>
 		</dependency>
 

--- a/wicket-kendo-ui-themes/theme-default/pom.xml
+++ b/wicket-kendo-ui-themes/theme-default/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>com.googlecode.wicket-jquery-ui</groupId>
 		<artifactId>wicket-kendo-ui-themes</artifactId>
-		<version>9.11.1-SNAPSHOT</version>
+		<version>10.0.0-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>wicket-kendo-ui-theme-default</artifactId>
@@ -22,7 +22,7 @@
 		<dependency>
 			<groupId>com.googlecode.wicket-jquery-ui</groupId>
 			<artifactId>wicket-kendo-ui</artifactId>
-			<version>9.11.1-SNAPSHOT</version>
+			<version>10.0.0-SNAPSHOT</version>
 			<scope>provided</scope>
 		</dependency>
 

--- a/wicket-kendo-ui-themes/theme-fiori/pom.xml
+++ b/wicket-kendo-ui-themes/theme-fiori/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>com.googlecode.wicket-jquery-ui</groupId>
 		<artifactId>wicket-kendo-ui-themes</artifactId>
-		<version>9.11.1-SNAPSHOT</version>
+		<version>10.0.0-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>wicket-kendo-ui-theme-fiori</artifactId>
@@ -22,7 +22,7 @@
 		<dependency>
 			<groupId>com.googlecode.wicket-jquery-ui</groupId>
 			<artifactId>wicket-kendo-ui</artifactId>
-			<version>9.11.1-SNAPSHOT</version>
+			<version>10.0.0-SNAPSHOT</version>
 			<scope>provided</scope>
 		</dependency>
 

--- a/wicket-kendo-ui-themes/theme-flat/pom.xml
+++ b/wicket-kendo-ui-themes/theme-flat/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>com.googlecode.wicket-jquery-ui</groupId>
 		<artifactId>wicket-kendo-ui-themes</artifactId>
-		<version>9.11.1-SNAPSHOT</version>
+		<version>10.0.0-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>wicket-kendo-ui-theme-flat</artifactId>
@@ -22,7 +22,7 @@
 		<dependency>
 			<groupId>com.googlecode.wicket-jquery-ui</groupId>
 			<artifactId>wicket-kendo-ui</artifactId>
-			<version>9.11.1-SNAPSHOT</version>
+			<version>10.0.0-SNAPSHOT</version>
 			<scope>provided</scope>
 		</dependency>
 

--- a/wicket-kendo-ui-themes/theme-high-contrast/pom.xml
+++ b/wicket-kendo-ui-themes/theme-high-contrast/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>com.googlecode.wicket-jquery-ui</groupId>
 		<artifactId>wicket-kendo-ui-themes</artifactId>
-		<version>9.11.1-SNAPSHOT</version>
+		<version>10.0.0-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>wicket-kendo-ui-theme-highcontrast</artifactId>
@@ -22,7 +22,7 @@
 		<dependency>
 			<groupId>com.googlecode.wicket-jquery-ui</groupId>
 			<artifactId>wicket-kendo-ui</artifactId>
-			<version>9.11.1-SNAPSHOT</version>
+			<version>10.0.0-SNAPSHOT</version>
 			<scope>provided</scope>
 		</dependency>
 

--- a/wicket-kendo-ui-themes/theme-material-black/pom.xml
+++ b/wicket-kendo-ui-themes/theme-material-black/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>com.googlecode.wicket-jquery-ui</groupId>
 		<artifactId>wicket-kendo-ui-themes</artifactId>
-		<version>9.11.1-SNAPSHOT</version>
+		<version>10.0.0-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>wicket-kendo-ui-theme-materialblack</artifactId>
@@ -22,7 +22,7 @@
 		<dependency>
 			<groupId>com.googlecode.wicket-jquery-ui</groupId>
 			<artifactId>wicket-kendo-ui</artifactId>
-			<version>9.11.1-SNAPSHOT</version>
+			<version>10.0.0-SNAPSHOT</version>
 			<scope>provided</scope>
 		</dependency>
 

--- a/wicket-kendo-ui-themes/theme-material/pom.xml
+++ b/wicket-kendo-ui-themes/theme-material/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>com.googlecode.wicket-jquery-ui</groupId>
 		<artifactId>wicket-kendo-ui-themes</artifactId>
-		<version>9.11.1-SNAPSHOT</version>
+		<version>10.0.0-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>wicket-kendo-ui-theme-material</artifactId>
@@ -22,7 +22,7 @@
 		<dependency>
 			<groupId>com.googlecode.wicket-jquery-ui</groupId>
 			<artifactId>wicket-kendo-ui</artifactId>
-			<version>9.11.1-SNAPSHOT</version>
+			<version>10.0.0-SNAPSHOT</version>
 			<scope>provided</scope>
 		</dependency>
 

--- a/wicket-kendo-ui-themes/theme-metro-black/pom.xml
+++ b/wicket-kendo-ui-themes/theme-metro-black/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>com.googlecode.wicket-jquery-ui</groupId>
 		<artifactId>wicket-kendo-ui-themes</artifactId>
-		<version>9.11.1-SNAPSHOT</version>
+		<version>10.0.0-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>wicket-kendo-ui-theme-metroblack</artifactId>
@@ -22,7 +22,7 @@
 		<dependency>
 			<groupId>com.googlecode.wicket-jquery-ui</groupId>
 			<artifactId>wicket-kendo-ui</artifactId>
-			<version>9.11.1-SNAPSHOT</version>
+			<version>10.0.0-SNAPSHOT</version>
 			<scope>provided</scope>
 		</dependency>
 

--- a/wicket-kendo-ui-themes/theme-metro/pom.xml
+++ b/wicket-kendo-ui-themes/theme-metro/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>com.googlecode.wicket-jquery-ui</groupId>
 		<artifactId>wicket-kendo-ui-themes</artifactId>
-		<version>9.11.1-SNAPSHOT</version>
+		<version>10.0.0-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>wicket-kendo-ui-theme-metro</artifactId>
@@ -22,7 +22,7 @@
 		<dependency>
 			<groupId>com.googlecode.wicket-jquery-ui</groupId>
 			<artifactId>wicket-kendo-ui</artifactId>
-			<version>9.11.1-SNAPSHOT</version>
+			<version>10.0.0-SNAPSHOT</version>
 			<scope>provided</scope>
 		</dependency>
 

--- a/wicket-kendo-ui-themes/theme-moonlight/pom.xml
+++ b/wicket-kendo-ui-themes/theme-moonlight/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>com.googlecode.wicket-jquery-ui</groupId>
 		<artifactId>wicket-kendo-ui-themes</artifactId>
-		<version>9.11.1-SNAPSHOT</version>
+		<version>10.0.0-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>wicket-kendo-ui-theme-moonlight</artifactId>
@@ -22,7 +22,7 @@
 		<dependency>
 			<groupId>com.googlecode.wicket-jquery-ui</groupId>
 			<artifactId>wicket-kendo-ui</artifactId>
-			<version>9.11.1-SNAPSHOT</version>
+			<version>10.0.0-SNAPSHOT</version>
 			<scope>provided</scope>
 		</dependency>
 

--- a/wicket-kendo-ui-themes/theme-nova/pom.xml
+++ b/wicket-kendo-ui-themes/theme-nova/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>com.googlecode.wicket-jquery-ui</groupId>
 		<artifactId>wicket-kendo-ui-themes</artifactId>
-		<version>9.11.1-SNAPSHOT</version>
+		<version>10.0.0-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>wicket-kendo-ui-theme-nova</artifactId>
@@ -22,7 +22,7 @@
 		<dependency>
 			<groupId>com.googlecode.wicket-jquery-ui</groupId>
 			<artifactId>wicket-kendo-ui</artifactId>
-			<version>9.11.1-SNAPSHOT</version>
+			<version>10.0.0-SNAPSHOT</version>
 			<scope>provided</scope>
 		</dependency>
 

--- a/wicket-kendo-ui-themes/theme-office365/pom.xml
+++ b/wicket-kendo-ui-themes/theme-office365/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>com.googlecode.wicket-jquery-ui</groupId>
 		<artifactId>wicket-kendo-ui-themes</artifactId>
-		<version>9.11.1-SNAPSHOT</version>
+		<version>10.0.0-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>wicket-kendo-ui-theme-office365</artifactId>
@@ -22,7 +22,7 @@
 		<dependency>
 			<groupId>com.googlecode.wicket-jquery-ui</groupId>
 			<artifactId>wicket-kendo-ui</artifactId>
-			<version>9.11.1-SNAPSHOT</version>
+			<version>10.0.0-SNAPSHOT</version>
 			<scope>provided</scope>
 		</dependency>
 

--- a/wicket-kendo-ui-themes/theme-silver/pom.xml
+++ b/wicket-kendo-ui-themes/theme-silver/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>com.googlecode.wicket-jquery-ui</groupId>
 		<artifactId>wicket-kendo-ui-themes</artifactId>
-		<version>9.11.1-SNAPSHOT</version>
+		<version>10.0.0-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>wicket-kendo-ui-theme-silver</artifactId>
@@ -22,7 +22,7 @@
 		<dependency>
 			<groupId>com.googlecode.wicket-jquery-ui</groupId>
 			<artifactId>wicket-kendo-ui</artifactId>
-			<version>9.11.1-SNAPSHOT</version>
+			<version>10.0.0-SNAPSHOT</version>
 			<scope>provided</scope>
 		</dependency>
 

--- a/wicket-kendo-ui-themes/theme-uniform/pom.xml
+++ b/wicket-kendo-ui-themes/theme-uniform/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>com.googlecode.wicket-jquery-ui</groupId>
 		<artifactId>wicket-kendo-ui-themes</artifactId>
-		<version>9.11.1-SNAPSHOT</version>
+		<version>10.0.0-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>wicket-kendo-ui-theme-uniform</artifactId>
@@ -22,7 +22,7 @@
 		<dependency>
 			<groupId>com.googlecode.wicket-jquery-ui</groupId>
 			<artifactId>wicket-kendo-ui</artifactId>
-			<version>9.11.1-SNAPSHOT</version>
+			<version>10.0.0-SNAPSHOT</version>
 			<scope>provided</scope>
 		</dependency>
 

--- a/wicket-kendo-ui/pom.xml
+++ b/wicket-kendo-ui/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>com.googlecode.wicket-jquery-ui</groupId>
 		<artifactId>wicket-jquery-ui-parent</artifactId>
-		<version>9.11.1-SNAPSHOT</version>
+		<version>10.0.0-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>wicket-kendo-ui</artifactId>
@@ -22,7 +22,7 @@
 		<dependency>
 			<groupId>com.googlecode.wicket-jquery-ui</groupId>
 			<artifactId>wicket-jquery-ui-core</artifactId>
-			<version>9.11.1-SNAPSHOT</version>
+			<version>10.0.0-SNAPSHOT</version>
 		</dependency>
 
 		<!-- WICKET DEPENDENCIES -->


### PR DESCRIPTION
- Set version to 10.0.0-SNAPSHOT
- Update Wicket to 10.0.0-M1-SNAPSHOT
- Update maven-war-plugin to enable builds on Java 19

Best create a wicket10.x branch and re-target this PR.